### PR TITLE
Edits for alignment with the JS API specification

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,2353 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <title>WebAssembly JavaScript Interface</title>
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <meta content="ED" name="w3c-status">
+  <meta content="This document provides an explicit JavaScript API for interacting with WebAssembly." name="abstract">
+  <meta content="Bikeshed version 66a76cd06d4fa9e491630583356008a71a166760" name="generator">
+  <link href="https://www.w3.org/TR/wasm-js-api-1/" rel="canonical">
+  <meta content="6df5721e4081c9629505a1019a2abe9f7b6ee192" name="document-revision">
+<style>/* style-md-lists */
+
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}</style>
+<style>/* style-selflinks */
+
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: gray;
+    color: white;
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: black;
+}
+
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }</style>
+<style>/* style-counters */
+
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
+
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
+
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}</style>
+<style>/* style-autolinks */
+
+.css.css, .property.property, .descriptor.descriptor {
+    color: #005a9c;
+    font-size: inherit;
+    font-family: inherit;
+}
+.css::before, .property::before, .descriptor::before {
+    content: "‘";
+}
+.css::after, .property::after, .descriptor::after {
+    content: "’";
+}
+.property, .descriptor {
+    /* Don't wrap property and descriptor names */
+    white-space: nowrap;
+}
+.type { /* CSS value <type> */
+    font-style: italic;
+}
+pre .property::before, pre .property::after {
+    content: "";
+}
+[data-link-type="property"]::before,
+[data-link-type="propdesc"]::before,
+[data-link-type="descriptor"]::before,
+[data-link-type="value"]::before,
+[data-link-type="function"]::before,
+[data-link-type="at-rule"]::before,
+[data-link-type="selector"]::before,
+[data-link-type="maybe"]::before {
+    content: "‘";
+}
+[data-link-type="property"]::after,
+[data-link-type="propdesc"]::after,
+[data-link-type="descriptor"]::after,
+[data-link-type="value"]::after,
+[data-link-type="function"]::after,
+[data-link-type="at-rule"]::after,
+[data-link-type="selector"]::after,
+[data-link-type="maybe"]::after {
+    content: "’";
+}
+
+[data-link-type].production::before,
+[data-link-type].production::after,
+.prod [data-link-type]::before,
+.prod [data-link-type]::after {
+    content: "";
+}
+
+[data-link-type=element],
+[data-link-type=element-attr] {
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-size: .9em;
+}
+[data-link-type=element]::before { content: "<" }
+[data-link-type=element]::after  { content: ">" }
+
+[data-link-type=biblio] {
+    white-space: pre;
+}</style>
+<style>/* style-dfn-panel */
+
+        .dfn-panel {
+            position: absolute;
+            z-index: 35;
+            height: auto;
+            width: -webkit-fit-content;
+            width: fit-content;
+            max-width: 300px;
+            max-height: 500px;
+            overflow: auto;
+            padding: 0.5em 0.75em;
+            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+            background: #DDDDDD;
+            color: black;
+            border: outset 0.2em;
+        }
+        .dfn-panel:not(.on) { display: none; }
+        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+        .dfn-panel > b { display: block; }
+        .dfn-panel a { color: black; }
+        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+        .dfn-panel > b + b { margin-top: 0.25em; }
+        .dfn-panel ul { padding: 0; }
+        .dfn-panel li { list-style: inside; }
+        .dfn-panel.activated {
+            display: inline-block;
+            position: fixed;
+            left: .5em;
+            bottom: 2em;
+            margin: 0 auto;
+            max-width: calc(100vw - 1.5em - .4em - .5em);
+            max-height: 30vh;
+        }
+
+        .dfn-paneled { cursor: pointer; }
+        </style>
+<style>/* style-syntax-highlighting */
+pre.idl.highlight { color: #708090; }
+.highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+.highlight .c { color: #708090 } /* Comment */
+.highlight .k { color: #990055 } /* Keyword */
+.highlight .l { color: #000000 } /* Literal */
+.highlight .n { color: #0077aa } /* Name */
+.highlight .o { color: #999999 } /* Operator */
+.highlight .p { color: #999999 } /* Punctuation */
+.highlight .cm { color: #708090 } /* Comment.Multiline */
+.highlight .cp { color: #708090 } /* Comment.Preproc */
+.highlight .c1 { color: #708090 } /* Comment.Single */
+.highlight .cs { color: #708090 } /* Comment.Special */
+.highlight .kc { color: #990055 } /* Keyword.Constant */
+.highlight .kd { color: #990055 } /* Keyword.Declaration */
+.highlight .kn { color: #990055 } /* Keyword.Namespace */
+.highlight .kp { color: #990055 } /* Keyword.Pseudo */
+.highlight .kr { color: #990055 } /* Keyword.Reserved */
+.highlight .kt { color: #990055 } /* Keyword.Type */
+.highlight .ld { color: #000000 } /* Literal.Date */
+.highlight .m { color: #000000 } /* Literal.Number */
+.highlight .s { color: #a67f59 } /* Literal.String */
+.highlight .na { color: #0077aa } /* Name.Attribute */
+.highlight .nc { color: #0077aa } /* Name.Class */
+.highlight .no { color: #0077aa } /* Name.Constant */
+.highlight .nd { color: #0077aa } /* Name.Decorator */
+.highlight .ni { color: #0077aa } /* Name.Entity */
+.highlight .ne { color: #0077aa } /* Name.Exception */
+.highlight .nf { color: #0077aa } /* Name.Function */
+.highlight .nl { color: #0077aa } /* Name.Label */
+.highlight .nn { color: #0077aa } /* Name.Namespace */
+.highlight .py { color: #0077aa } /* Name.Property */
+.highlight .nt { color: #669900 } /* Name.Tag */
+.highlight .nv { color: #222222 } /* Name.Variable */
+.highlight .ow { color: #999999 } /* Operator.Word */
+.highlight .mb { color: #000000 } /* Literal.Number.Bin */
+.highlight .mf { color: #000000 } /* Literal.Number.Float */
+.highlight .mh { color: #000000 } /* Literal.Number.Hex */
+.highlight .mi { color: #000000 } /* Literal.Number.Integer */
+.highlight .mo { color: #000000 } /* Literal.Number.Oct */
+.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+.highlight .sc { color: #a67f59 } /* Literal.String.Char */
+.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+.highlight .se { color: #a67f59 } /* Literal.String.Escape */
+.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+.highlight .sx { color: #a67f59 } /* Literal.String.Other */
+.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+.highlight .vc { color: #0077aa } /* Name.Variable.Class */
+.highlight .vg { color: #0077aa } /* Name.Variable.Global */
+.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+</style>
+  <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
+   <h1 class="p-name no-ref" id="title">WebAssembly JavaScript Interface</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-19">19 October 2018</time></span></h2>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="https://webassembly.github.io/spec/js-api/">https://webassembly.github.io/spec/js-api/</a>
+     <dt>Latest published version:
+     <dd><a href="https://www.w3.org/TR/wasm-js-api-1/">https://www.w3.org/TR/wasm-js-api-1/</a>
+     <dt>Issue Tracking:
+     <dd><a href="#issues-index">Inline In Spec</a>
+     <dd><a href="https://github.com/WebAssembly/spec/labels/wasm-js-api-1">GitHub Issues</a>
+     <dt class="editor">Editor:
+     <dd class="editor p-author h-card vcard"><span class="p-name fn">Daniel Ehrenberg (Igalia)</span>
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
+   <hr title="Separator for header">
+  </div>
+  <div class="p-summary" data-fill-with="abstract">
+   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+   <p>This document provides an explicit JavaScript API for interacting with WebAssembly.</p>
+    Part of a collection of related documents:
+the <a href="https://www.w3.org/TR/wasm-core/">Core WebAssembly Specification</a>,
+the <a href="https://www.w3.org/TR/wasm-js-api/">WebAssembly JS Interface</a>,
+and the <a href="https://www.w3.org/TR/wasm-web-api/">WebAssembly Web API</a>. 
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
+  <div data-fill-with="status">
+   <p> This is a public copy of the editors’ draft.
+	It is provided for discussion only and may change at any moment.
+	Its publication here does not imply endorsement of its contents by W3C.
+	Don’t cite this document other than as work in progress. </p>
+   <p> <a href="https://github.com/WebAssembly/spec/issues">GitHub Issues</a> are preferred for discussion of this specification.
+  All issues and comments are <a href="https://github.com/WebAssembly/spec/issues?utf8=%E2%9C%93&amp;q=is%3Aissue++">archived</a>. </p>
+   <p> This document was produced by the <a href="https://www.w3.org/wasm/">WebAssembly Working Group</a>. </p>
+   <p> This document was produced by a group operating under
+	the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
+	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/101196/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
+	that page also includes instructions for disclosing a patent.
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
+   <p> This document is governed by the <a href="https://www.w3.org/2018/Process-20180201/" id="w3c_process_revision">1 February 2018 W3C Process Document</a>. </p>
+   <p></p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li><a href="#sample"><span class="secno">1</span> <span class="content">Sample API Usage</span></a>
+    <li>
+     <a href="#webassembly-storage"><span class="secno">2</span> <span class="content">Internal storage</span></a>
+     <ol class="toc">
+      <li><a href="#store"><span class="secno">2.1</span> <span class="content">Interaction of the WebAssembly Store with JavaScript</span></a>
+      <li><a href="#object-caches"><span class="secno">2.2</span> <span class="content">WebAssembly JS Object Caches</span></a>
+     </ol>
+    <li>
+     <a href="#webassembly-namespace"><span class="secno">3</span> <span class="content">The WebAssembly Namespace</span></a>
+     <ol class="toc">
+      <li><a href="#modules"><span class="secno">3.1</span> <span class="content">Modules</span></a>
+      <li><a href="#instances"><span class="secno">3.2</span> <span class="content">Instances</span></a>
+      <li><a href="#memories"><span class="secno">3.3</span> <span class="content">Memories</span></a>
+      <li><a href="#tables"><span class="secno">3.4</span> <span class="content">Tables</span></a>
+      <li><a href="#exported-function-exotic-objects"><span class="secno">3.5</span> <span class="content">Exported Functions</span></a>
+      <li><a href="#error-objects"><span class="secno">3.6</span> <span class="content">Error Objects</span></a>
+     </ol>
+    <li>
+     <a href="#errors"><span class="secno">4</span> <span class="content">Error Condition Mappings to JavaScript</span></a>
+     <ol class="toc">
+      <li><a href="#stack-overflow"><span class="secno">4.1</span> <span class="content">Stack Overflow</span></a>
+      <li><a href="#out-of-memory"><span class="secno">4.2</span> <span class="content">Out of Memory</span></a>
+     </ol>
+    <li>
+     <a href="#esm-integration"><span class="secno">5</span> <span class="content">Integration with ECMAScript modules</span></a>
+     <ol class="toc">
+      <li><a href="#get-exported-names"><span class="secno">5.1</span> <span class="content">GetExportedNames ( <var>exportStarSet</var> ) Concrete Method</span></a>
+      <li><a href="#resolve-export"><span class="secno">5.2</span> <span class="content">ResolveExport ( <var>exportName</var>, <var>resolveSet</var> ) Concrete Method</span></a>
+      <li><a href="#module-declaration-environment-setup"><span class="secno">5.3</span> <span class="content">ModuleDeclarationEnvironmentSetup ( ) Concrete Method</span></a>
+      <li><a href="#module-execution"><span class="secno">5.4</span> <span class="content">ModuleExecution ( ) Concrete Method</span></a>
+      <li><a href="#html-modifications"><span class="secno">5.5</span> <span class="content">Modifications to HTML</span></a>
+     </ol>
+    <li>
+     <a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
+     <ol class="toc">
+      <li><a href="#document-conventions"><span class="secno"></span> <span class="content"> Document conventions</span></a>
+     </ol>
+    <li>
+     <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ol class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+      <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
+     </ol>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ol class="toc">
+      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
+     </ol>
+    <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
+    <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
+   </ol>
+  </nav>
+  <main>
+   <p>This API privides a way to access WebAssembly <a data-link-type="biblio" href="#biblio-webassembly">[WEBASSEMBLY]</a> through a bridge to explicitly construct modules from JavaScript <a data-link-type="biblio" href="#biblio-ecmascript">[ECMASCRIPT]</a>.</p>
+   <p>See the <a href="#issues-index">Issues Index</a> for complete list of issues.</p>
+   <h2 class="heading settled" data-level="1" id="sample"><span class="secno">1. </span><span class="content">Sample API Usage</span><a class="self-link" href="#sample"></a></h2>
+   <p><em>This section is non-normative.</em></p>
+   <p>Given <code>demo.wat</code> (encoded to <code>demo.wasm</code>):</p>
+<pre class="language-lisp highlight"><span class="p">(</span><span class="nv">module</span>
+    <span class="p">(</span>import <span class="s">"js"</span> <span class="s">"import1"</span> <span class="p">(</span><span class="nv">func</span> <span class="nv">$i1</span><span class="p">))</span>
+    <span class="p">(</span>import <span class="s">"js"</span> <span class="s">"import2"</span> <span class="p">(</span><span class="nv">func</span> <span class="nv">$i2</span><span class="p">))</span>
+    <span class="p">(</span><span class="nv">func</span> <span class="nv">$main</span> <span class="p">(</span><span class="nv">call</span> <span class="nv">$i1</span><span class="p">))</span>
+    <span class="p">(</span><span class="nv">start</span> <span class="nv">$main</span><span class="p">)</span>
+    <span class="p">(</span><span class="nv">func</span> <span class="p">(</span>export <span class="s">"f"</span><span class="p">)</span> <span class="p">(</span><span class="nv">call</span> <span class="nv">$i2</span><span class="p">))</span>
+<span class="p">)</span>
+</pre>
+   <p>and the following JavaScript, run in a browser:</p>
+<pre class="language-javascript highlight"><span class="kd">var</span> importObj <span class="o">=</span> <span class="p">{</span>js<span class="o">:</span> <span class="p">{</span>
+    import1<span class="o">:</span> <span class="p">()</span> <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span><span class="s2">"hello,"</span><span class="p">),</span>
+    import2<span class="o">:</span> <span class="p">()</span> <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span><span class="s2">"world!"</span><span class="p">)</span>
+<span class="p">}};</span>
+fetch<span class="p">(</span><span class="s1">'demo.wasm'</span><span class="p">).</span>then<span class="p">(</span>response <span class="p">=></span>
+    response<span class="p">.</span>arrayBuffer<span class="p">()</span>
+<span class="p">).</span>then<span class="p">(</span>buffer <span class="p">=></span>
+    WebAssembly<span class="p">.</span>instantiate<span class="p">(</span>buffer<span class="p">,</span> importObj<span class="p">)</span>
+<span class="p">).</span>then<span class="p">(({</span>module<span class="p">,</span> instance<span class="p">})</span> <span class="p">=></span>
+    instance<span class="p">.</span>exports<span class="p">.</span>f<span class="p">()</span>
+<span class="p">);</span>
+</pre>
+   <h2 class="heading settled" data-level="2" id="webassembly-storage"><span class="secno">2. </span><span class="content">Internal storage</span><a class="self-link" href="#webassembly-storage"></a></h2>
+   <h3 class="heading settled" data-level="2.1" id="store"><span class="secno">2.1. </span><span class="content">Interaction of the WebAssembly Store with JavaScript</span><a class="self-link" href="#store"></a></h3>
+   <p class="note" role="note"><span>Note:</span> WebAssembly semantics are defined in terms of an abstract <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-store" id="ref-for-syntax-store">store</a>, representing the state of the WebAssembly abstract machine. WebAssembly operations take a store and return an updated store.</p>
+   <p>Each <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#agent" id="ref-for-agent">agent</a> has an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="associated-store">associated store</dfn>. When a new agent is created, its associated store is set to the result of <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-init-store" id="ref-for-embed-init-store">init_store</a>().</p>
+   <p class="note" role="note"><span>Note:</span> In this specification, no WebAssembly-related objects, memory or addresses can be shared among agents in an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-agent-clusters" id="ref-for-sec-agent-clusters">agent cluster</a>. In a future version of WebAssembly, this may change.</p>
+   <p>Elements of the WebAssembly store may be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="identified-with">identified with</dfn> JavaScript values. In particular, each WebAssembly <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#memory-instances" id="ref-for-memory-instances">memory instance</a> with a corresponding <code class="idl"><a data-link-type="idl" href="#memory" id="ref-for-memory">Memory</a></code> object is identified with a JavaScript <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-data-blocks" id="ref-for-sec-data-blocks">Data Block</a>; modifications to this Data Block are identified to updating the agent’s store to a store which reflects those changes, and vice versa.</p>
+   <h3 class="heading settled" data-level="2.2" id="object-caches"><span class="secno">2.2. </span><span class="content">WebAssembly JS Object Caches</span><a class="self-link" href="#object-caches"></a></h3>
+   <p class="note" role="note"><span>Note:</span> There are several WebAssembly objects that may have a corresponding JavaScript object. The correspondence is stored in a per-agent mapping from WebAssembly <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#addresses" id="ref-for-addresses">address</a>es to JavaScript objects. This mapping is used to ensure that, for a given <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#agent" id="ref-for-agent①">agent</a>, there exists at most one JavaScript object for a particular WebAssembly address.</p>
+   <p>Each <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#agent" id="ref-for-agent②">agent</a> is associated with the following <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">ordered map</a>s:</p>
+   <ul>
+    <li data-md="">
+     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="memory-object-cache">Memory object cache</dfn>, mapping <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-memaddr" id="ref-for-syntax-memaddr">memory address</a>es to <code class="idl"><a data-link-type="idl" href="#memory" id="ref-for-memory①">Memory</a></code> objects.</p>
+    <li data-md="">
+     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="table-object-cache">Table object cache</dfn>, mapping <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-tableaddr" id="ref-for-syntax-tableaddr">table address</a>es to <code class="idl"><a data-link-type="idl" href="#table" id="ref-for-table">Table</a></code> objects.</p>
+    <li data-md="">
+     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="exported-function-cache">Exported Function cache</dfn>, mapping <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-funcaddr" id="ref-for-syntax-funcaddr">function address</a>es to <a data-link-type="dfn" href="#exported-function" id="ref-for-exported-function">Exported Function</a> objects.</p>
+   </ul>
+   <h2 class="heading settled" data-level="3" id="webassembly-namespace"><span class="secno">3. </span><span class="content">The WebAssembly Namespace</span><a class="self-link" href="#webassembly-namespace"></a></h2>
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-webassemblyinstantiatedsource"><code>WebAssemblyInstantiatedSource</code></dfn> {
+    <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#module" id="ref-for-module">Module</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="WebAssemblyInstantiatedSource" data-dfn-type="dict-member" data-export="" data-type="Module " id="dom-webassemblyinstantiatedsource-module"><code>module</code></dfn>;
+    <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#instance" id="ref-for-instance">Instance</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="WebAssemblyInstantiatedSource" data-dfn-type="dict-member" data-export="" data-type="Instance " id="dom-webassemblyinstantiatedsource-instance"><code>instance</code></dfn>;
+};
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>,<span class="n">Worklet</span>)]
+<span class="kt">namespace</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="namespace" data-export="" id="namespacedef-webassembly"><code>WebAssembly</code></dfn> {
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-webassembly-validate" id="ref-for-dom-webassembly-validate">validate</a>(<a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#BufferSource" id="ref-for-BufferSource">BufferSource</a> <dfn class="nv idl-code" data-dfn-for="WebAssembly/validate(bytes)" data-dfn-type="argument" data-export="" id="dom-webassembly-validate-bytes-bytes"><code>bytes</code><a class="self-link" href="#dom-webassembly-validate-bytes-bytes"></a></dfn>);
+    <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#module" id="ref-for-module①">Module</a>> <a class="nv idl-code" data-link-type="method" href="#dom-webassembly-compile" id="ref-for-dom-webassembly-compile">compile</a>(<a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#BufferSource" id="ref-for-BufferSource①">BufferSource</a> <dfn class="nv idl-code" data-dfn-for="WebAssembly/compile(bytes)" data-dfn-type="argument" data-export="" id="dom-webassembly-compile-bytes-bytes"><code>bytes</code><a class="self-link" href="#dom-webassembly-compile-bytes-bytes"></a></dfn>);
+
+    <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-webassemblyinstantiatedsource" id="ref-for-dictdef-webassemblyinstantiatedsource">WebAssemblyInstantiatedSource</a>> <a class="nv idl-code" data-link-type="method" href="#dom-webassembly-instantiate" id="ref-for-dom-webassembly-instantiate">instantiate</a>(
+        <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#BufferSource" id="ref-for-BufferSource②">BufferSource</a> <dfn class="nv idl-code" data-dfn-for="WebAssembly/instantiate(bytes, importObject), WebAssembly/instantiate(bytes)" data-dfn-type="argument" data-export="" id="dom-webassembly-instantiate-bytes-importobject-bytes"><code>bytes</code><a class="self-link" href="#dom-webassembly-instantiate-bytes-importobject-bytes"></a></dfn>, <span class="kt">optional</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object"><span class="kt">object</span></a> <dfn class="nv idl-code" data-dfn-for="WebAssembly/instantiate(bytes, importObject), WebAssembly/instantiate(bytes)" data-dfn-type="argument" data-export="" id="dom-webassembly-instantiate-bytes-importobject-importobject"><code>importObject</code><a class="self-link" href="#dom-webassembly-instantiate-bytes-importobject-importobject"></a></dfn>);
+
+    <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#instance" id="ref-for-instance①">Instance</a>> <a class="nv idl-code" data-link-type="method" href="#dom-webassembly-instantiate-moduleobject-importobject" id="ref-for-dom-webassembly-instantiate-moduleobject-importobject">instantiate</a>(
+        <a class="n" data-link-type="idl-name" href="#module" id="ref-for-module②">Module</a> <dfn class="nv idl-code" data-dfn-for="WebAssembly/instantiate(moduleObject, importObject), WebAssembly/instantiate(moduleObject)" data-dfn-type="argument" data-export="" id="dom-webassembly-instantiate-moduleobject-importobject-moduleobject"><code>moduleObject</code><a class="self-link" href="#dom-webassembly-instantiate-moduleobject-importobject-moduleobject"></a></dfn>, <span class="kt">optional</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object①"><span class="kt">object</span></a> <dfn class="nv idl-code" data-dfn-for="WebAssembly/instantiate(moduleObject, importObject), WebAssembly/instantiate(moduleObject)" data-dfn-type="argument" data-export="" id="dom-webassembly-instantiate-moduleobject-importobject-importobject"><code>importObject</code><a class="self-link" href="#dom-webassembly-instantiate-moduleobject-importobject-importobject"></a></dfn>);
+};
+</pre>
+   <div class="algorithm" data-algorithm="compile a WebAssembly module">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="compile-a-webassembly-module">compile a WebAssembly module</dfn> from a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#BufferSource" id="ref-for-BufferSource③">BufferSource</a></code> <var>bytes</var>, perform the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>module</var> be <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-decode-module" id="ref-for-embed-decode-module">decode_module</a>(<var>bytes</var>). If <var>module</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error">error</a>, return <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error①">error</a>.</p>
+     <li data-md="">
+      <p>If <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-validate-module" id="ref-for-embed-validate-module">validate_module</a>(<var>module</var>) is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error②">error</a>, return <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error③">error</a>.</p>
+     <li data-md="">
+      <p>Return <var>module</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="validate(bytes)">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="WebAssembly" data-dfn-type="method" data-export="" id="dom-webassembly-validate"><code>validate(bytes)</code></dfn> method, when invoked, performs the following steps: 
+    <ol>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="#compile-a-webassembly-module" id="ref-for-compile-a-webassembly-module">Compile</a> <var>bytes</var> as a WebAssembly module and store the results as <var>module</var>.</p>
+     <li data-md="">
+      <p>If <var>module</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error④">error</a>, return false.</p>
+     <li data-md="">
+      <p>Return true.</p>
+    </ol>
+   </div>
+   <div>
+     A <code class="idl"><a data-link-type="idl" href="#module" id="ref-for-module③">Module</a></code> object represents a single WebAssembly module. Each <code class="idl"><a data-link-type="idl" href="#module" id="ref-for-module④">Module</a></code> object has the following internal slots: 
+    <ul>
+     <li data-md="">
+      <p>[[Module]] : a WebAssembly <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/modules.html#syntax-module" id="ref-for-syntax-module">module</a></p>
+     <li data-md="">
+      <p>[[Bytes]] : an <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects" id="ref-for-sec-arraybuffer-objects">ArrayBuffer</a></code> which is source bytes of [[Module]].</p>
+    </ul>
+   </div>
+   <div class="algorithm" data-algorithm="construct a WebAssembly module object">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="construct-a-webassembly-module-object">construct a WebAssembly module object</dfn> from a module <var>module</var> and source bytes <var>bytes</var>, perform the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>moduleObject</var> be a new <code class="idl"><a data-link-type="idl" href="#module" id="ref-for-module⑤">Module</a></code> object.</p>
+     <li data-md="">
+      <p>Set <var>moduleObject</var>.[[Module]] to <var>module</var>.</p>
+     <li data-md="">
+      <p>Set <var>moduleObject</var>.[[Bytes]] to <var>bytes</var>.</p>
+     <li data-md="">
+      <p>Return <var>moduleObject</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="asynchronously compile a WebAssembly module">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="asynchronously-compile-a-webassembly-module">asynchronously compile a WebAssembly module</dfn> from a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#BufferSource" id="ref-for-BufferSource④">BufferSource</a></code> <var>bytes</var>, with the promise <var>promise</var>, using optional <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source" id="ref-for-task-source">task source</a> <var>taskSource</var>, perform the following steps: 
+    <ol>
+     <li data-md="">
+      <p>In parallel, <a data-link-type="dfn" href="#compile-a-webassembly-module" id="ref-for-compile-a-webassembly-module①">compile the WebAssembly module</a> <var>bytes</var> and store the result as <var>module</var>.</p>
+     <li data-md="">
+      <p>When the above operation completes, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task">queue a task</a> to perform the following steps. If <var>taskSource</var> was provided, queue the task on that task source.</p>
+      <ol>
+       <li data-md="">
+        <p>If <var>module</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error⑤">error</a>, reject <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="#compileerror" id="ref-for-compileerror">CompileError</a></code> exception.</p>
+       <li data-md="">
+        <p>Otherwise,</p>
+        <ol>
+         <li data-md="">
+          <p><a data-link-type="dfn" href="#construct-a-webassembly-module-object" id="ref-for-construct-a-webassembly-module-object">Construct a WebAssembly module object</a> from <var>module</var> and <var>bytes</var>, and let <var>moduleObject</var> be the result.</p>
+         <li data-md="">
+          <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise">Resolve</a> <var>promise</var> with <var>moduleObject</var>.</p>
+        </ol>
+      </ol>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="compile(bytes)">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="WebAssembly" data-dfn-type="method" data-export="" id="dom-webassembly-compile"><code>compile(bytes)</code></dfn> method, when invoked, performs the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>stableBytes</var> be a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy" id="ref-for-dfn-get-buffer-source-copy">copy of the bytes held by the buffer</a> <var>bytes</var>.</p>
+     <li data-md="">
+      <p>Let <var>promise</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise">a new promise</a>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="#asynchronously-compile-a-webassembly-module" id="ref-for-asynchronously-compile-a-webassembly-module">Asynchronously compile a WebAssembly module</a> from <var>stableBytes</var> with <var>promise</var>.</p>
+     <li data-md="">
+      <p>Return <var>promise</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="instantiate">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="instantiate-a-webassembly-module">instantiate a WebAssembly module</dfn> from a <code class="idl"><a data-link-type="idl" href="#module" id="ref-for-module⑥">Module</a></code> <var>moduleObject</var> and imports <var>importObject</var>, perform the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>module</var> be <var>moduleObject</var>.[[Module]].</p>
+     <li data-md="">
+      <p>If <var>module</var>.<a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/modules.html#syntax-module" id="ref-for-syntax-module①">𝗂𝗆𝗉𝗈𝗋𝗍𝗌</a> is not an empty list, and <var>importObject</var> is undefined, throw a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror" id="ref-for-sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> exception.</p>
+     <li data-md="">
+      <p>Let <var>imports</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval">external value</a>s.</p>
+     <li data-md="">
+      <p>For each (<var>moduleName</var>, <var>componentName</var>, <var>externtype</var>) in <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-imports" id="ref-for-embed-imports">module_imports</a>(<var>module</var>), do</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>o</var> be ? <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p" id="ref-for-sec-get-o-p">Get</a>(<var>importObject</var>, <var>moduleName</var>).</p>
+       <li data-md="">
+        <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values" id="ref-for-sec-ecmascript-data-types-and-values">Type</a>(<var>o</var>) is not <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-object" id="ref-for-concept-url-object">Object</a>, throw a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror" id="ref-for-sec-native-error-types-used-in-this-standard-typeerror①">TypeError</a></code> exception.</p>
+       <li data-md="">
+        <p>Let <var>v</var> be ? <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p" id="ref-for-sec-get-o-p①">Get</a>(<var>o</var>, <var>componentName</var>)</p>
+       <li data-md="">
+        <p>If <var>externtype</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#external-types" id="ref-for-external-types">𝖿𝗎𝗇𝖼</a> <var>functype</var>,</p>
+        <ol>
+         <li data-md="">
+          <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable" id="ref-for-sec-iscallable">IsCallable</a>(<var>v</var>) is false, throw a <code class="idl"><a data-link-type="idl" href="#linkerror" id="ref-for-linkerror">LinkError</a></code> exception.</p>
+         <li data-md="">
+          <p>If <var>v</var> has a [[FunctionAddress]] internal slot, and therefore is an <a data-link-type="dfn" href="#exported-function" id="ref-for-exported-function①">Exported Function</a>,</p>
+          <ol>
+           <li data-md="">
+            <p>Let <var>funcaddr</var> be the value of <var>v</var>’s [[FunctionAddress]] internal slot.</p>
+          </ol>
+          <p class="note" role="note"><span>Note:</span> The signature is checked by <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-instantiate-module" id="ref-for-embed-instantiate-module">instantiate_module</a> invoked below.</p>
+         <li data-md="">
+          <p>Otherwise,</p>
+          <ol>
+           <li data-md="">
+            <p><a data-link-type="dfn" href="#create-a-host-function" id="ref-for-create-a-host-function">Create a host function</a> from <var>v</var> and let <var>funcaddr</var> be the result.</p>
+           <li data-md="">
+            <p>Let <var>index</var> be the number of external functions in <var>imports</var>. This value <var>index</var> is known as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="index-of-the-host-function">index of the host function</dfn> <var>funcaddr</var>.</p>
+          </ol>
+         <li data-md="">
+          <p>Let <var>externfunc</var> be the <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval①">external value</a> <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval②">𝖿𝗎𝗇𝖼</a> <var>funcaddr</var>.</p>
+         <li data-md="">
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>externfunc</var> to <var>imports</var>.</p>
+        </ol>
+       <li data-md="">
+        <p>If <var>externtype</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#external-types" id="ref-for-external-types①">𝗀𝗅𝗈𝖻𝖺𝗅</a> <var>globaltype</var>,</p>
+        <ol>
+         <li data-md="">
+          <p>If <var>globaltype</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-valtype" id="ref-for-syntax-valtype">𝗂𝟨𝟦</a> or <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values" id="ref-for-sec-ecmascript-data-types-and-values①">Type</a>(<var>v</var>) is not <a data-link-type="dfn" href="https://drafts.csswg.org/css-values-4/#number" id="ref-for-number">Number</a>, throw a <code class="idl"><a data-link-type="idl" href="#linkerror" id="ref-for-linkerror①">LinkError</a></code> exception.</p>
+         <li data-md="">
+          <p>Let <var>value</var> be <a data-link-type="dfn" href="#towebassemblyvalue" id="ref-for-towebassemblyvalue">ToWebAssemblyValue</a>(<var>v</var>, <var>globaltype</var>.<em><a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-globaltype" id="ref-for-syntax-globaltype">valtype</a></em>)</p>
+         <li data-md="">
+          <p class="assertion">Assert: <var>globaltype</var>.<em><a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-globaltype" id="ref-for-syntax-globaltype①">mut</a></em> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-globaltype" id="ref-for-syntax-globaltype②">𝖼𝗈𝗇𝗌𝗍</a>, as verified by WebAssembly validation.</p>
+         <li data-md="">
+          <p>Let <var>store</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store">associated store</a>.</p>
+         <li data-md="">
+          <p>Let (<var>store</var>, <var>globaladdr</var>) be <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-alloc-global" id="ref-for-embed-alloc-global">alloc_global</a>(<var>store</var>, <var>globaltype</var>, <var>value</var>).</p>
+         <li data-md="">
+          <p>Set the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent①">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store①">associated store</a> to <var>store</var>.</p>
+         <li data-md="">
+          <p>Let <var>externglobal</var> be <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval③">𝗀𝗅𝗈𝖻𝖺𝗅</a> <var>globaladdr</var>.</p>
+         <li data-md="">
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append①">Append</a> <var>externglobal</var> to <var>imports</var>.</p>
+        </ol>
+       <li data-md="">
+        <p>If <var>externtype</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#external-types" id="ref-for-external-types②">𝗆𝖾𝗆</a> <var>memtype</var>,</p>
+        <ol>
+         <li data-md="">
+          <p>If <var>v</var> is not a <code class="idl"><a data-link-type="idl" href="#memory" id="ref-for-memory②">Memory</a></code> object, throw a <code class="idl"><a data-link-type="idl" href="#linkerror" id="ref-for-linkerror②">LinkError</a></code> exception.</p>
+        </ol>
+        <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-instantiate-module" id="ref-for-embed-instantiate-module①">instantiate_module</a> invoked below will check the imported <code class="idl"><a data-link-type="idl" href="#memory" id="ref-for-memory③">Memory</a></code>'s size against the importing module’s requirements.</p>
+        <ol start="2">
+         <li data-md="">
+          <p>Let <var>externmem</var> be the <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval④">external value</a> <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval⑤">𝗆𝖾𝗆</a> <var>v</var>.[[Memory]].</p>
+         <li data-md="">
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append②">Append</a> <var>externmem</var> to <var>imports</var>.</p>
+        </ol>
+       <li data-md="">
+        <p>Otherwise, <var>externtype</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#external-types" id="ref-for-external-types③">𝗍𝖺𝖻𝗅𝖾</a> <var>tabletype</var>,</p>
+        <ol>
+         <li data-md="">
+          <p>If <var>v</var> is not a <code class="idl"><a data-link-type="idl" href="#table" id="ref-for-table①">Table</a></code> instance, throw a <code class="idl"><a data-link-type="idl" href="#linkerror" id="ref-for-linkerror③">LinkError</a></code> exception.</p>
+        </ol>
+        <p class="note" role="note"><span>Note:</span> The table’s length, etc. is checked by <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-instantiate-module" id="ref-for-embed-instantiate-module②">instantiate_module</a> invoked below.</p>
+        <ol start="2">
+         <li data-md="">
+          <p>Let <var>tableaddr</var> be <var>v</var>.[[Table]]</p>
+         <li data-md="">
+          <p>Let <var>externtable</var> be the <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval⑥">external value</a> <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval⑦">𝗍𝖺𝖻𝗅𝖾</a> <var>tableaddr</var>.</p>
+         <li data-md="">
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append③">Append</a> <var>externtable</var> to <var>imports</var>.</p>
+        </ol>
+      </ol>
+     <li data-md="">
+      <p>Let (<var>store</var>, <var>instance</var>) be <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-instantiate-module" id="ref-for-embed-instantiate-module③">instantiate_module</a>(<var>store</var>, <var>module</var>, <var>imports</var>).</p>
+     <li data-md="">
+      <p>If <var>instance</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error⑥">error</a>, throw an appropriate exception type:</p>
+      <ul>
+       <li data-md="">
+        <p>A <code class="idl"><a data-link-type="idl" href="#linkerror" id="ref-for-linkerror④">LinkError</a></code> exception for most cases which occur during linking.</p>
+       <li data-md="">
+        <p>If the error came when running the start function, throw a <code class="idl"><a data-link-type="idl" href="#runtimeerror" id="ref-for-runtimeerror">RuntimeError</a></code> for most errors which occur from WebAssembly, or the error object propagated from inner ECMAScript code.</p>
+       <li data-md="">
+        <p>Another error type if appropriate, for example an out-of-memory exception, as documented in <a href="#errors">the WebAssembly error mapping</a>.</p>
+      </ul>
+     <li data-md="">
+      <p>Let <var>exportsObject</var> be ! <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-objectcreate" id="ref-for-sec-objectcreate">ObjectCreate</a>(null).</p>
+     <li data-md="">
+      <p>For each pair (<var>name</var>, <var>externtype</var>) in <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-exports" id="ref-for-embed-exports">module_exports</a>(<var>module</var>),</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>externval</var> be <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-get-export" id="ref-for-embed-get-export">get_export</a>(<var>instance</var>, <var>name</var>).</p>
+       <li data-md="">
+        <p class="assertion">Assert: <var>externval</var> is not <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error⑦">error</a>.</p>
+       <li data-md="">
+        <p>If <var>externtype</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#external-types" id="ref-for-external-types④">𝖿𝗎𝗇𝖼</a> <var>functype</var>,</p>
+        <ol>
+         <li data-md="">
+          <p class="assertion">Assert: <var>externval</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval⑧">𝖿𝗎𝗇𝖼</a> <var>funcaddr</var>.</p>
+         <li data-md="">
+          <p>Let <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval⑨">𝖿𝗎𝗇𝖼</a> <var>funcaddr</var> be <var>externval</var>.</p>
+         <li data-md="">
+          <p>Let <var>func</var> be the result of creating <a data-link-type="dfn" href="#a-new-exported-function" id="ref-for-a-new-exported-function">a new Exported Function</a> from <var>funcaddr</var>.</p>
+         <li data-md="">
+          <p>Let <var>value</var> be <var>func</var>.</p>
+        </ol>
+       <li data-md="">
+        <p>If <var>externtype</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#external-types" id="ref-for-external-types⑤">𝗀𝗅𝗈𝖻𝖺𝗅</a> <var>globaltype</var>,</p>
+        <ol>
+         <li data-md="">
+          <p>If <var>globaltype</var>.<em><a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-globaltype" id="ref-for-syntax-globaltype③">valtype</a></em>) is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-valtype" id="ref-for-syntax-valtype①">𝗂𝟨𝟦</a>, throw a <code class="idl"><a data-link-type="idl" href="#linkerror" id="ref-for-linkerror⑤">LinkError</a></code> exception.</p>
+         <li data-md="">
+          <p class="assertion">Assert: <var>globaltype</var>.<em><a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-globaltype" id="ref-for-syntax-globaltype④">mut</a></em> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-globaltype" id="ref-for-syntax-globaltype⑤">𝖼𝗈𝗇𝗌𝗍</a>, as verified by WebAssembly validation.</p>
+         <li data-md="">
+          <p class="assertion">Assert: <var>externval</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval①⓪">𝗀𝗅𝗈𝖻𝖺𝗅</a> <var>globaladdr</var>.</p>
+         <li data-md="">
+          <p>Let <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval①①">𝗀𝗅𝗈𝖻𝖺𝗅</a> <var>globaladdr</var> be <var>externval</var>.</p>
+         <li data-md="">
+          <p>Let <var>value</var> be <a data-link-type="dfn" href="#tojsvalue" id="ref-for-tojsvalue">ToJSValue</a>(<a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-read-global" id="ref-for-embed-read-global">read_global</a>(<var>store</var>, <var>globaladdr</var>)).</p>
+        </ol>
+       <li data-md="">
+        <p>If <var>externtype</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#external-types" id="ref-for-external-types⑥">𝗆𝖾𝗆</a> <var>memtype</var>,</p>
+        <ol>
+         <li data-md="">
+          <p class="assertion">Assert: <var>externval</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval①②">𝗆𝖾𝗆</a> <var>memaddr</var>.</p>
+         <li data-md="">
+          <p>Let <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval①③">𝗆𝖾𝗆</a> <var>memaddr</var> be <var>externval</var>.</p>
+         <li data-md="">
+          <p>Let <var>memory</var> be <a data-link-type="dfn" href="#create-a-memory-object" id="ref-for-create-a-memory-object">a new Memory object</a> created from <var>memaddr</var>.</p>
+         <li data-md="">
+          <p>Let <var>value</var> be <var>memory</var>.</p>
+        </ol>
+       <li data-md="">
+        <p>Otherwise, <var>externtype</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#external-types" id="ref-for-external-types⑦">𝗍𝖺𝖻𝗅𝖾</a> <var>tabletype</var>,</p>
+        <ol>
+         <li data-md="">
+          <p class="assertion">Assert: <var>externval</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval①④">𝗍𝖺𝖻𝗅𝖾</a> <var>tableaddr</var>.</p>
+         <li data-md="">
+          <p>Let <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval" id="ref-for-syntax-externval①⑤">𝗍𝖺𝖻𝗅𝖾</a> <var>tableaddr</var> be <var>externval</var>.</p>
+         <li data-md="">
+          <p>Let <var>table</var> be <a data-link-type="dfn" href="#create-a-table-object" id="ref-for-create-a-table-object">a new Table object</a> created from <var>tableaddr</var>.</p>
+         <li data-md="">
+          <p>Let <var>value</var> be <var>table</var>.</p>
+        </ol>
+       <li data-md="">
+        <p>Let <var>status</var> be ! <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createdataproperty" id="ref-for-sec-createdataproperty">CreateDataProperty</a>(<var>exportsObject</var>, <var>name</var>, <var>value</var>).</p>
+       <li data-md="">
+        <p class="assertion">Assert: <var>status</var> is true.</p>
+      </ol>
+      <p class="note" role="note"><span>Note:</span> the validity and uniqueness checks performed during <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/valid/modules.html#valid-module" id="ref-for-valid-module">WebAssembly module validation</a> ensure that each property name is valid and no properties are defined twice.</p>
+     <li data-md="">
+      <p>Perform ! <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-setintegritylevel" id="ref-for-sec-setintegritylevel">SetIntegrityLevel</a>(<var>exportsObject</var>, <code>"frozen"</code>).</p>
+     <li data-md="">
+      <p>Let <var>instanceObject</var> be a new <code class="idl"><a data-link-type="idl" href="#instance" id="ref-for-instance②">Instance</a></code> object whose internal [[Instance]] slot is set to <var>instance</var> and the [[Exports]] slot to <var>exportsObject</var>.</p>
+     <li data-md="">
+      <p>Return <var>instanceObject</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="instantiate a promise of a module">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="instantiate-a-promise-of-a-module">instantiate a promise of a module</dfn> <var>promiseOfModule</var> with imports <var>importObject</var>, perform the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>promise</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise①">a new promise</a></p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment" id="ref-for-upon-fulfillment">Upon fulfillment</a> of <var>promiseOfModule</var> with value <var>module</var>:</p>
+      <ol>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="#instantiate-a-webassembly-module" id="ref-for-instantiate-a-webassembly-module">Instantiate the WebAssembly module</a> <var>module</var> importing <var>importObject</var>, and let <var>instance</var> be the result.  If this throws an exception, catch it, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise">reject</a> <var>promise</var> with the exception, and abort these substeps.</p>
+       <li data-md="">
+        <p>Let <var>result</var> be a <code class="idl"><a data-link-type="idl" href="#dictdef-webassemblyinstantiatedsource" id="ref-for-dictdef-webassemblyinstantiatedsource①">WebAssemblyInstantiatedSource</a></code> dictionary with <code class="idl"><a data-link-type="idl" href="#dom-webassemblyinstantiatedsource-module" id="ref-for-dom-webassemblyinstantiatedsource-module">module</a></code> set to <var>module</var> and <code class="idl"><a data-link-type="idl" href="#dom-webassemblyinstantiatedsource-instance" id="ref-for-dom-webassemblyinstantiatedsource-instance">instance</a></code> set to <var>instance</var>.</p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise①">Resolve</a> <var>promise</var> with <var>result</var>.</p>
+      </ol>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection" id="ref-for-upon-rejection">Upon rejection</a> of <var>promiseOfModule</var> with reason <var>reason</var>:</p>
+      <ol>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise①">Reject</a> <var>promise</var> with <var>reason</var>.</p>
+      </ol>
+     <li data-md="">
+      <p>Return <var>promise</var>.</p>
+    </ol>
+    <p class="note" role="note"><span>Note:</span> It would be valid to perform certain parts of the instantiation <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>, but several parts need to happen in the event loop, including JavaScript operations to access the <var>importObject</var> and execution of the start function.</p>
+   </div>
+   <div class="algorithm" data-algorithm="instantiate(bytes, importObject)">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="WebAssembly" data-dfn-type="method" data-export="" data-lt="instantiate(bytes, importObject)|instantiate(bytes)" id="dom-webassembly-instantiate"><code>instantiate(bytes, importObject)</code></dfn> method, when invoked, performs the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>stableBytes</var> be a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy" id="ref-for-dfn-get-buffer-source-copy①">copy of the bytes held by the buffer</a> <var>bytes</var>.</p>
+     <li data-md="">
+      <p>Let <var>promiseOfModule</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="#asynchronously-compile-a-webassembly-module" id="ref-for-asynchronously-compile-a-webassembly-module①">Asynchronously compile a WebAssembly module</a> from <var>stableBytes</var> with <var>promiseOfModule</var>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="#instantiate-a-promise-of-a-module" id="ref-for-instantiate-a-promise-of-a-module">Instantiate</a> <var>promiseOfModule</var> with imports <var>importObject</var> and return the result.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="instantiate(moduleObject, importObject)">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="WebAssembly" data-dfn-type="method" data-export="" data-lt="instantiate(moduleObject, importObject)|instantiate(moduleObject)" id="dom-webassembly-instantiate-moduleobject-importobject"><code>instantiate(moduleObject, importObject)</code></dfn> method, when invoked, performs the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>promise</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise③">a new promise</a>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task①">Queue a task</a> to perform the following steps:</p>
+      <ol>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="#instantiate-a-webassembly-module" id="ref-for-instantiate-a-webassembly-module①">Instantiate the WebAssembly module</a> <var>module</var> importing <var>importObject</var>, and let <var>instance</var> be the result.  If this throws an exception, catch it, and <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise②">reject</a> <var>promise</var> with the exception.</p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise②">Resolve</a> <var>promise</var> with <var>instance</var>.</p>
+      </ol>
+     <li data-md="">
+      <p>Return <var>promise</var></p>
+    </ol>
+   </div>
+   <p class="note" role="note"><span>Note:</span> A follow-on streaming API is documented in the <a href="https://webassembly.github.io/spec/web-api/index.html">WebAssembly Web API</a>.</p>
+   <h3 class="heading settled" data-level="3.1" id="modules"><span class="secno">3.1. </span><span class="content">Modules</span><a class="self-link" href="#modules"></a></h3>
+<pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-importexportkind"><code>ImportExportKind</code></dfn> {
+  <dfn class="s idl-code" data-dfn-for="ImportExportKind" data-dfn-type="enum-value" data-export="" data-lt="&quot;function&quot;|function" id="dom-importexportkind-function"><code>"function"</code><a class="self-link" href="#dom-importexportkind-function"></a></dfn>,
+  <dfn class="s idl-code" data-dfn-for="ImportExportKind" data-dfn-type="enum-value" data-export="" data-lt="&quot;table&quot;|table" id="dom-importexportkind-table"><code>"table"</code><a class="self-link" href="#dom-importexportkind-table"></a></dfn>,
+  <dfn class="s idl-code" data-dfn-for="ImportExportKind" data-dfn-type="enum-value" data-export="" data-lt="&quot;memory&quot;|memory" id="dom-importexportkind-memory"><code>"memory"</code><a class="self-link" href="#dom-importexportkind-memory"></a></dfn>,
+  <dfn class="s idl-code" data-dfn-for="ImportExportKind" data-dfn-type="enum-value" data-export="" data-lt="&quot;global&quot;|global" id="dom-importexportkind-global"><code>"global"</code><a class="self-link" href="#dom-importexportkind-global"></a></dfn>
+};
+
+<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-moduleexportdescriptor"><code>ModuleExportDescriptor</code></dfn> {
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ModuleExportDescriptor" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-moduleexportdescriptor-name"><code>name</code></dfn>;
+  <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-importexportkind" id="ref-for-enumdef-importexportkind">ImportExportKind</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ModuleExportDescriptor" data-dfn-type="dict-member" data-export="" data-type="ImportExportKind " id="dom-moduleexportdescriptor-kind"><code>kind</code></dfn>;
+  // Note: Other fields such as signature may be added in the future.
+};
+
+<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-moduleimportdescriptor"><code>ModuleImportDescriptor</code></dfn> {
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ModuleImportDescriptor" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-moduleimportdescriptor-module"><code>module</code></dfn>;
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ModuleImportDescriptor" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-moduleimportdescriptor-name"><code>name</code></dfn>;
+  <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-importexportkind" id="ref-for-enumdef-importexportkind①">ImportExportKind</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ModuleImportDescriptor" data-dfn-type="dict-member" data-export="" data-type="ImportExportKind " id="dom-moduleimportdescriptor-kind"><code>kind</code></dfn>;
+};
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly">WebAssembly</a>, <a class="nv idl-code" data-link-type="constructor" href="#dom-module-module" id="ref-for-dom-module-module">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#BufferSource" id="ref-for-BufferSource⑤">BufferSource</a> <dfn class="nv idl-code" data-dfn-for="Module/Module(bytes)" data-dfn-type="argument" data-export="" id="dom-module-module-bytes-bytes"><code>bytes</code><a class="self-link" href="#dom-module-module-bytes-bytes"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>,<span class="n">Worklet</span>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="module"><code>Module</code></dfn> {
+  <span class="kt">static</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-moduleexportdescriptor" id="ref-for-dictdef-moduleexportdescriptor">ModuleExportDescriptor</a>> <dfn class="nv idl-code" data-dfn-for="Module" data-dfn-type="method" data-export="" data-lt="exports(module)" id="dom-module-exports"><code>exports</code><a class="self-link" href="#dom-module-exports"></a></dfn>(<a class="n" data-link-type="idl-name" href="#module" id="ref-for-module⑦">Module</a> <dfn class="nv idl-code" data-dfn-for="Module/exports(module)" data-dfn-type="argument" data-export="" id="dom-module-exports-module-module"><code>module</code><a class="self-link" href="#dom-module-exports-module-module"></a></dfn>);
+  <span class="kt">static</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-moduleimportdescriptor" id="ref-for-dictdef-moduleimportdescriptor">ModuleImportDescriptor</a>> <dfn class="nv idl-code" data-dfn-for="Module" data-dfn-type="method" data-export="" data-lt="imports(module)" id="dom-module-imports"><code>imports</code><a class="self-link" href="#dom-module-imports"></a></dfn>(<a class="n" data-link-type="idl-name" href="#module" id="ref-for-module⑧">Module</a> <dfn class="nv idl-code" data-dfn-for="Module/imports(module)" data-dfn-type="argument" data-export="" id="dom-module-imports-module-module"><code>module</code><a class="self-link" href="#dom-module-imports-module-module"></a></dfn>);
+  <span class="kt">static</span> <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects" id="ref-for-sec-arraybuffer-objects①"><span class="kt">ArrayBuffer</span></a>> <dfn class="nv idl-code" data-dfn-for="Module" data-dfn-type="method" data-export="" data-lt="customSections(module, sectionName)" id="dom-module-customsections"><code>customSections</code><a class="self-link" href="#dom-module-customsections"></a></dfn>(<a class="n" data-link-type="idl-name" href="#module" id="ref-for-module⑨">Module</a> <dfn class="nv idl-code" data-dfn-for="Module/customSections(module, sectionName)" data-dfn-type="argument" data-export="" id="dom-module-customsections-module-sectionname-module"><code>module</code><a class="self-link" href="#dom-module-customsections-module-sectionname-module"></a></dfn>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③"><span class="kt">USVString</span></a> <dfn class="nv idl-code" data-dfn-for="Module/customSections(module, sectionName)" data-dfn-type="argument" data-export="" id="dom-module-customsections-module-sectionname-sectionname"><code>sectionName</code><a class="self-link" href="#dom-module-customsections-module-sectionname-sectionname"></a></dfn>);
+};
+</pre>
+   <div class="algorithm" data-algorithm="string value of the extern type">
+     The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="string-value-of-the-extern-type">string value of the extern type</dfn> <var>type</var> is 
+    <ul>
+     <li data-md="">
+      <p>"function" if <var>type</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#external-types" id="ref-for-external-types⑧">𝖿𝗎𝗇𝖼</a> functype</p>
+     <li data-md="">
+      <p>"table" if <var>type</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#external-types" id="ref-for-external-types⑨">𝗍𝖺𝖻𝗅𝖾</a> tabletype</p>
+     <li data-md="">
+      <p>"memory" if <var>type</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#external-types" id="ref-for-external-types①⓪">𝗆𝖾𝗆</a> memtype</p>
+     <li data-md="">
+      <p>"global" if <var>type</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#external-types" id="ref-for-external-types①①">𝗀𝗅𝗈𝖻𝖺𝗅</a> globaltype</p>
+    </ul>
+   </div>
+   <div class="algorithm" data-algorithm="exports(moduleObject)">
+     The <dfn class="idl-code" data-dfn-for="Module" data-dfn-type="method" data-export="" id="dom-module-exports-moduleobject"><code>exports(moduleObject)</code><a class="self-link" href="#dom-module-exports-moduleobject"></a></dfn> method, when invoked, performs the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>module</var> be <var>moduleObject</var>.[[Module]].</p>
+     <li data-md="">
+      <p>Let <var>exports</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a>.</p>
+     <li data-md="">
+      <p>For each (<var>name</var>, <var>type</var>) in <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-exports" id="ref-for-embed-exports①">module_exports</a>(<var>module</var>)</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>kind</var> be the <a data-link-type="dfn" href="#string-value-of-the-extern-type" id="ref-for-string-value-of-the-extern-type">string value of the extern type</a> <var>type</var>.</p>
+       <li data-md="">
+        <p>Let <var>obj</var> be a new <code class="idl"><a data-link-type="idl" href="#dictdef-moduleexportdescriptor" id="ref-for-dictdef-moduleexportdescriptor①">ModuleExportDescriptor</a></code> dictionary with <code class="idl"><a data-link-type="idl" href="#dom-moduleexportdescriptor-name" id="ref-for-dom-moduleexportdescriptor-name">name</a></code> <var>name</var> and <code class="idl"><a data-link-type="idl" href="#dom-moduleexportdescriptor-kind" id="ref-for-dom-moduleexportdescriptor-kind">kind</a></code> <var>kind</var>.</p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append④">Append</a> <var>obj</var> to the end of <var>exports</var>.</p>
+      </ol>
+     <li data-md="">
+      <p>Return <var>exports</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="imports(moduleObject)">
+     The <dfn class="idl-code" data-dfn-for="Module" data-dfn-type="method" data-export="" id="dom-module-imports-moduleobject"><code>imports(moduleObject)</code><a class="self-link" href="#dom-module-imports-moduleobject"></a></dfn> method, when invoked, performs the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>module</var> be <var>moduleObject</var>.[[Module]].</p>
+     <li data-md="">
+      <p>Let <var>imports</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a>.</p>
+     <li data-md="">
+      <p>For each (<var>moduleName</var>, <var>name</var>, <var>type</var>) in <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-imports" id="ref-for-embed-imports①">module_imports</a>(<var>module</var>),</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>kind</var> be the <a data-link-type="dfn" href="#string-value-of-the-extern-type" id="ref-for-string-value-of-the-extern-type①">string value of the extern type</a> <var>type</var>.</p>
+       <li data-md="">
+        <p>Let <var>obj</var> be a new <code class="idl"><a data-link-type="idl" href="#dictdef-moduleimportdescriptor" id="ref-for-dictdef-moduleimportdescriptor①">ModuleImportDescriptor</a></code> dictionary with <code class="idl"><a data-link-type="idl" href="#dom-moduleimportdescriptor-module" id="ref-for-dom-moduleimportdescriptor-module">module</a></code> <var>moduleName</var>, <code class="idl"><a data-link-type="idl" href="#dom-moduleimportdescriptor-name" id="ref-for-dom-moduleimportdescriptor-name">name</a></code> <var>name</var> and <code class="idl"><a data-link-type="idl" href="#dom-moduleimportdescriptor-kind" id="ref-for-dom-moduleimportdescriptor-kind">kind</a></code> <var>kind</var>.</p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append⑤">Append</a> <var>obj</var> to the end of <var>imports</var>.</p>
+      </ol>
+     <li data-md="">
+      <p>Return <var>imports</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="customSections(moduleObject, sectionName)">
+     The <dfn class="idl-code" data-dfn-for="Module" data-dfn-type="method" data-export="" id="dom-module-customsections-moduleobject-sectionname"><code>customSections(moduleObject, sectionName)</code><a class="self-link" href="#dom-module-customsections-moduleobject-sectionname"></a></dfn> method, when invoked, performs the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>bytes</var> be <var>moduleObject</var>.[[Bytes]].</p>
+     <li data-md="">
+      <p>Let <var>customSections</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects" id="ref-for-sec-arraybuffer-objects②">ArrayBuffer</a></code>s.</p>
+     <li data-md="">
+      <p>For each <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/binary/modules.html#custom-section" id="ref-for-custom-section">custom section</a> <var>customSection</var> in the binary format of <var>bytes</var>,</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>name</var> be the <code>name</code> of the custom section, <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom-or-fail" id="ref-for-utf-8-decode-without-bom-or-fail">decoded as UTF-8</a>.</p>
+       <li data-md="">
+        <p class="assertion">Assert: <var>name</var> is not failure (<var>moduleObject</var>.[[Module]] is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/valid/modules.html#valid-module" id="ref-for-valid-module①">valid</a>).</p>
+       <li data-md="">
+        <p>If <var>name</var> equals <var>secondName</var> as string values,</p>
+        <ol>
+         <li data-md="">
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append⑥">Append</a> a new <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects" id="ref-for-sec-arraybuffer-objects③">ArrayBuffer</a></code> containing a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy" id="ref-for-dfn-get-buffer-source-copy②">copy of the bytes held by the buffer</a> <var>bytes</var> for the range matched by this <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/binary/modules.html#binary-customsec" id="ref-for-binary-customsec">customsec</a> production.</p>
+        </ol>
+      </ol>
+     <li data-md="">
+      <p>Return <var>customSections</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="Module(bytes)">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="Module" data-dfn-type="constructor" data-export="" id="dom-module-module"><code>Module(bytes)</code></dfn> constructor, when invoked, performs the follwing steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>stableBytes</var> be a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy" id="ref-for-dfn-get-buffer-source-copy③">copy of the bytes held by the buffer</a> <var>bytes</var>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="#compile-a-webassembly-module" id="ref-for-compile-a-webassembly-module②">Compile the WebAssembly module</a> <var>stableBytes</var> and store the result as <var>module</var>.</p>
+     <li data-md="">
+      <p>If <var>module</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error⑧">error</a>, throw a <code class="idl"><a data-link-type="idl" href="#compileerror" id="ref-for-compileerror①">CompileError</a></code> exception.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="#construct-a-webassembly-module-object" id="ref-for-construct-a-webassembly-module-object①">Construct a WebAssembly module object</a> from <var>module</var> and <var>bytes</var>, and return the result.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="3.2" id="instances"><span class="secno">3.2. </span><span class="content">Instances</span><a class="self-link" href="#instances"></a></h3>
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace①">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly①">WebAssembly</a>, <a class="nv idl-code" data-link-type="constructor" href="#dom-instance-instance" id="ref-for-dom-instance-instance">Constructor</a>(<a class="n" data-link-type="idl-name" href="#module" id="ref-for-module①⓪">Module</a> <dfn class="nv idl-code" data-dfn-for="Instance/Instance(module, importObject)" data-dfn-type="argument" data-export="" id="dom-instance-instance-module-importobject-module"><code>module</code><a class="self-link" href="#dom-instance-instance-module-importobject-module"></a></dfn>, <span class="kt">optional</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object②"><span class="kt">object</span></a> <dfn class="nv idl-code" data-dfn-for="Instance/Instance(module, importObject)" data-dfn-type="argument" data-export="" id="dom-instance-instance-module-importobject-importobject"><code>importObject</code><a class="self-link" href="#dom-instance-instance-module-importobject-importobject"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>,<span class="n">Worklet</span>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="instance"><code>Instance</code></dfn> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object③"><span class="kt">object</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="object" href="#dom-instance-exports" id="ref-for-dom-instance-exports">exports</a>;
+};
+</pre>
+   <div class="algorithm" data-algorithm="Instance(module, importObject)"> The <dfn class="dfn-paneled idl-code" data-dfn-for="Instance" data-dfn-type="constructor" data-export="" id="dom-instance-instance"><code>Instance(module, importObject)</code></dfn> constructor, when invoked, <a data-link-type="dfn" href="#instantiate-a-webassembly-module" id="ref-for-instantiate-a-webassembly-module②">instantiates the WebAssembly module</a> <var>module</var> importing <var>importObject</var> and returns the result. </div>
+   <div class="algorithm" data-algorithm="exports"> The getter of the <dfn class="dfn-paneled idl-code" data-dfn-for="Instance" data-dfn-type="attribute" data-export="" id="dom-instance-exports"><code>exports</code></dfn> attribute of <code class="idl"><a data-link-type="idl" href="#instance" id="ref-for-instance③">Instance</a></code> returns the receiver’s [[Exports]] internal slot. </div>
+   <h3 class="heading settled" data-level="3.3" id="memories"><span class="secno">3.3. </span><span class="content">Memories</span><a class="self-link" href="#memories"></a></h3>
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-memorydescriptor"><code>MemoryDescriptor</code></dfn> {
+  <span class="kt">required</span> [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <dfn class="nv idl-code" data-dfn-for="MemoryDescriptor" data-dfn-type="dict-member" data-export="" data-type="[EnforceRange] unsigned long " id="dom-memorydescriptor-initial"><code>initial</code><a class="self-link" href="#dom-memorydescriptor-initial"></a></dfn>;
+  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange①">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <dfn class="nv idl-code" data-dfn-for="MemoryDescriptor" data-dfn-type="dict-member" data-export="" data-type="unsigned long " id="dom-memorydescriptor-maximum"><code>maximum</code><a class="self-link" href="#dom-memorydescriptor-maximum"></a></dfn>;
+};
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace②">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly②">WebAssembly</a>, <a class="nv idl-code" data-link-type="constructor" href="#dom-memory-memory" id="ref-for-dom-memory-memory">Constructor</a>(<a class="n" data-link-type="idl-name" href="#dictdef-memorydescriptor" id="ref-for-dictdef-memorydescriptor">MemoryDescriptor</a> <dfn class="nv idl-code" data-dfn-for="Memory/Memory(descriptor)" data-dfn-type="argument" data-export="" id="dom-memory-memory-descriptor-descriptor"><code>descriptor</code><a class="self-link" href="#dom-memory-memory-descriptor-descriptor"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>,<span class="n">Worklet</span>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="memory"><code>Memory</code></dfn> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-memory-grow" id="ref-for-dom-memory-grow">grow</a>([<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange②">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③"><span class="kt">unsigned</span> <span class="kt">long</span></a> <dfn class="nv idl-code" data-dfn-for="Memory/grow(delta)" data-dfn-type="argument" data-export="" id="dom-memory-grow-delta-delta"><code>delta</code><a class="self-link" href="#dom-memory-grow-delta-delta"></a></dfn>);
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects" id="ref-for-sec-arraybuffer-objects④"><span class="kt">ArrayBuffer</span></a> <dfn class="nv idl-code" data-dfn-for="Memory" data-dfn-type="attribute" data-export="" data-readonly="" data-type="ArrayBuffer" id="dom-memory-buffer"><code>buffer</code><a class="self-link" href="#dom-memory-buffer"></a></dfn>;
+};
+</pre>
+   <div>
+     A <code class="idl"><a data-link-type="idl" href="#memory" id="ref-for-memory④">Memory</a></code> object represents a single <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#memory-instances" id="ref-for-memory-instances①">memory instance</a> which can be simultaneously referenced by multiple <code class="idl"><a data-link-type="idl" href="#instance" id="ref-for-instance④">Instance</a></code> objects. Each <code class="idl"><a data-link-type="idl" href="#memory" id="ref-for-memory⑤">Memory</a></code> object has the following internal slots: 
+    <ul>
+     <li data-md="">
+      <p>[[Memory]] : a <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-memaddr" id="ref-for-syntax-memaddr①">memory address</a></p>
+     <li data-md="">
+      <p>[[BufferObject]] : an <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects" id="ref-for-sec-arraybuffer-objects⑤">ArrayBuffer</a></code> whose <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-data-blocks" id="ref-for-sec-data-blocks①">Data Block</a> is <a data-link-type="dfn" href="#identified-with" id="ref-for-identified-with">identified with</a> the above memory address</p>
+    </ul>
+   </div>
+   <div class="algorithm" data-algorithm="create a memory object">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="create-a-memory-object">create a memory object</dfn> from a <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-memaddr" id="ref-for-syntax-memaddr②">memory address</a> <var>memaddr</var>, perform the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>map</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent②">surrounding agent</a>'s associated <a data-link-type="dfn" href="#memory-object-cache" id="ref-for-memory-object-cache">Memory object cache</a>.</p>
+     <li data-md="">
+      <p>If <var>map</var>[<var>memaddr</var>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists">exists</a>,</p>
+      <ol>
+       <li data-md="">
+        <p>Return <var>map</var>[<var>memaddr</var>].</p>
+      </ol>
+     <li data-md="">
+      <p>Let <var>block</var> be a Data Block which is <a data-link-type="dfn" href="#identified-with" id="ref-for-identified-with①">identified with</a> the underlying memory of <var>memaddr</var></p>
+     <li data-md="">
+      <p>Let <var>buffer</var> be a new <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects" id="ref-for-sec-arraybuffer-objects⑥">ArrayBuffer</a></code> whose [[ArrayBufferData]] is <var>block</var> and [[ArrayBufferByteLength]] is set to the length of <var>block</var>.</p>
+     <li data-md="">
+      <p>Let <var>memory</var> be a new <code class="idl"><a data-link-type="idl" href="#memory" id="ref-for-memory⑥">Memory</a></code> instance with [[Memory]] set to <var>memaddr</var> and [[BufferObject]] set to <var>buffer</var>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set">Set</a> <var>map</var>[<var>memaddr</var>] to <var>memory</var>.</p>
+     <li data-md="">
+      <p>Return <var>memory</var>.</p>
+    </ol>
+    <p class="issue" id="issue-cb23e866"><a class="self-link" href="#issue-cb23e866"></a> Any attempts to <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-detacharraybuffer" id="ref-for-sec-detacharraybuffer">detach</a> <var>buffer</var>, other than the detachment performed by <code class="idl"><a data-link-type="idl" href="#dom-memory-grow" id="ref-for-dom-memory-grow①">grow(delta)</a></code>, will throw a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror" id="ref-for-sec-native-error-types-used-in-this-standard-typeerror②">TypeError</a></code> exception. Specifying this behavior <a href="https://github.com/tc39/ecma262/issues/1024">requires changes to the ECMAScript specification</a>.</p>
+   </div>
+   <div class="algorithm" data-algorithm="Memory(descriptor)">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="Memory" data-dfn-type="constructor" data-export="" id="dom-memory-memory"><code>Memory(descriptor)</code></dfn> constructor, when invoked, performs the following steps: 
+    <ol>
+     <li data-md="">
+      <p>If <var>descriptor</var>["initial"] is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present" id="ref-for-dfn-present">present</a>, let <var>initial</var> be <var>descriptor</var>["initial"]; otherwise, let <var>initial</var> be 0.</p>
+     <li data-md="">
+      <p>If <var>descriptor</var>["maximum"] is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present" id="ref-for-dfn-present①">present</a>, let <var>maximum</var> be <var>descriptor</var>["maximum"]; otherwise, let <var>maximum</var> be empty.</p>
+     <li data-md="">
+      <p>Let <var>memtype</var> be { min <var>initial</var>, max <var>maximum</var> }</p>
+     <li data-md="">
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent③">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store②">associated store</a>.</p>
+     <li data-md="">
+      <p>Let (<var>store</var>, <var>memaddr</var>) be <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-alloc-mem" id="ref-for-embed-alloc-mem">alloc_mem</a>(<var>store</var>, <var>memtype</var>). If allocation fails, throw a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror" id="ref-for-sec-native-error-types-used-in-this-standard-rangeerror">RangeError</a></code> exception.</p>
+     <li data-md="">
+      <p>Set the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent④">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store③">associated store</a> to <var>store</var>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="#create-a-memory-object" id="ref-for-create-a-memory-object①">Create a memory object</a> from the memory address <var>memaddr</var> and return the result.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="reset the Memory buffer">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reset-the-memory-buffer">reset the Memory buffer</dfn> of <var>memaddr</var>, perform the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>map</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent⑤">surrounding agent</a>'s associated <a data-link-type="dfn" href="#memory-object-cache" id="ref-for-memory-object-cache①">Memory object cache</a>.</p>
+     <li data-md="">
+      <p class="assertion">Assert: <var>map</var>[<var>memaddr</var>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①">exists</a></p>
+     <li data-md="">
+      <p>Let <var>memory</var> be <var>map</var>[<var>memaddr</var>].</p>
+     <li data-md="">
+      <p>Perform ! <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-detacharraybuffer" id="ref-for-sec-detacharraybuffer①">DetachArrayBuffer</a>(<var>memory</var>.[[BufferObject]]).</p>
+     <li data-md="">
+      <p>Let <var>block</var> be a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-data-blocks" id="ref-for-sec-data-blocks②">Data Block</a> which is <a data-link-type="dfn" href="#identified-with" id="ref-for-identified-with②">identified with</a> the underlying memory of <var>memaddr</var>.</p>
+     <li data-md="">
+      <p>Let <var>buffer</var> be a new <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects" id="ref-for-sec-arraybuffer-objects⑦">ArrayBuffer</a></code> whose [[ArrayBufferData]] is <var>block</var> and [[ArrayBufferByteLength]] is set to the length of <var>block</var>.</p>
+     <li data-md="">
+      <p>Set <var>memory</var>.[[BufferObject]] to <var>buffer</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="grow(delta)">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="Memory" data-dfn-type="method" data-export="" id="dom-memory-grow"><code>grow(delta)</code></dfn> method, when invoked, performs the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>memory</var> be the Memory instance.</p>
+     <li data-md="">
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent⑥">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store④">associated store</a>.</p>
+     <li data-md="">
+      <p>Let <var>memaddr</var> be <var>memory</var>.[[Memory]].</p>
+     <li data-md="">
+      <p>Let <var>ret</var> be the <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-size-mem" id="ref-for-embed-size-mem">size_mem</a>(<var>store</var>, <var>memaddr</var>).</p>
+     <li data-md="">
+      <p>Let <var>store</var> be <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-grow-mem" id="ref-for-embed-grow-mem">grow_mem</a>(<var>store</var>, <var>memaddr</var>, <var>delta</var>).</p>
+     <li data-md="">
+      <p>If <var>store</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error⑨">error</a>, throw a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror" id="ref-for-sec-native-error-types-used-in-this-standard-rangeerror①">RangeError</a></code> exception.</p>
+     <li data-md="">
+      <p>Set the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent⑦">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store⑤">associated store</a> to <var>store</var>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="#reset-the-memory-buffer" id="ref-for-reset-the-memory-buffer">Reset the memory buffer</a> of <var>memaddr</var>.</p>
+     <li data-md="">
+      <p>Return <var>ret</var>.</p>
+    </ol>
+   </div>
+   <p>Immediately after a WebAssembly <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/instructions.html#exec-grow-memory" id="ref-for-exec-grow-memory">grow_memory</a> instruction executes, perform the following steps:</p>
+   <div class="algorithm" data-algorithm="grow_memory">
+    <ol>
+     <li data-md="">
+      <p>If the top of the stack is not <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#values" id="ref-for-values">𝗂𝟥𝟤.𝖼𝗈𝗇𝗌𝗍</a> (−1), then:</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>frame</var> be the <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/conventions.html#exec-notation-textual" id="ref-for-exec-notation-textual">current frame</a>.</p>
+       <li data-md="">
+        <p class="assertion">Assert: due to validation, <var>frame</var>.<a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-frame" id="ref-for-syntax-frame">𝗆𝗈𝖽𝗎𝗅𝖾</a>.<a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-moduleinst" id="ref-for-syntax-moduleinst">𝗆𝖾𝗆𝖺𝖽𝖽𝗋𝗌</a>[0] exists.</p>
+       <li data-md="">
+        <p>Let <var>memaddr</var> be the memory address <var>frame</var>.<a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-frame" id="ref-for-syntax-frame①">𝗆𝗈𝖽𝗎𝗅𝖾</a>.<a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-moduleinst" id="ref-for-syntax-moduleinst①">𝗆𝖾𝗆𝖺𝖽𝖽𝗋𝗌</a>[0].</p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="#reset-the-memory-buffer" id="ref-for-reset-the-memory-buffer①">Reset the memory buffer</a> of <var>memaddr</var>.</p>
+      </ol>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="3.4" id="tables"><span class="secno">3.4. </span><span class="content">Tables</span><a class="self-link" href="#tables"></a></h3>
+<pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-tablekind"><code>TableKind</code></dfn> {
+  <dfn class="s idl-code" data-dfn-for="TableKind" data-dfn-type="enum-value" data-export="" data-lt="&quot;anyfunc&quot;|anyfunc" id="dom-tablekind-anyfunc"><code>"anyfunc"</code><a class="self-link" href="#dom-tablekind-anyfunc"></a></dfn>,
+  // Note: More values may be added in future iterations,
+  // e.g., typed function references, typed GC references
+};
+
+<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-tabledescriptor"><code>TableDescriptor</code></dfn> {
+  <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-tablekind" id="ref-for-enumdef-tablekind">TableKind</a> <dfn class="nv idl-code" data-dfn-for="TableDescriptor" data-dfn-type="dict-member" data-export="" data-type="TableKind " id="dom-tabledescriptor-element"><code>element</code><a class="self-link" href="#dom-tabledescriptor-element"></a></dfn>;
+  <span class="kt">required</span> [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange③">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④"><span class="kt">unsigned</span> <span class="kt">long</span></a> <dfn class="nv idl-code" data-dfn-for="TableDescriptor" data-dfn-type="dict-member" data-export="" data-type="[EnforceRange] unsigned long " id="dom-tabledescriptor-initial"><code>initial</code><a class="self-link" href="#dom-tabledescriptor-initial"></a></dfn>;
+  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange④">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤"><span class="kt">unsigned</span> <span class="kt">long</span></a> <dfn class="nv idl-code" data-dfn-for="TableDescriptor" data-dfn-type="dict-member" data-export="" data-type="unsigned long " id="dom-tabledescriptor-maximum"><code>maximum</code><a class="self-link" href="#dom-tabledescriptor-maximum"></a></dfn>;
+};
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace③">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly③">WebAssembly</a>, <a class="nv idl-code" data-link-type="constructor" href="#dom-table-table" id="ref-for-dom-table-table">Constructor</a>(<a class="n" data-link-type="idl-name" href="#dictdef-tabledescriptor" id="ref-for-dictdef-tabledescriptor">TableDescriptor</a> <dfn class="nv idl-code" data-dfn-for="Table/Table(descriptor)" data-dfn-type="argument" data-export="" id="dom-table-table-descriptor-descriptor"><code>descriptor</code><a class="self-link" href="#dom-table-table-descriptor-descriptor"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>,<span class="n">Worklet</span>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="table"><code>Table</code></dfn> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑥"><span class="kt">unsigned</span> <span class="kt">long</span></a> <dfn class="nv idl-code" data-dfn-for="Table" data-dfn-type="method" data-export="" data-lt="grow(delta)" id="dom-table-grow"><code>grow</code><a class="self-link" href="#dom-table-grow"></a></dfn>([<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange⑤">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑦"><span class="kt">unsigned</span> <span class="kt">long</span></a> <dfn class="nv idl-code" data-dfn-for="Table/grow(delta)" data-dfn-type="argument" data-export="" id="dom-table-grow-delta-delta"><code>delta</code><a class="self-link" href="#dom-table-grow-delta-delta"></a></dfn>);
+  <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#Function" id="ref-for-Function">Function</a>? <a class="nv idl-code" data-link-type="method" href="#dom-table-get" id="ref-for-dom-table-get">get</a>([<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange⑥">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑧"><span class="kt">unsigned</span> <span class="kt">long</span></a> <dfn class="nv idl-code" data-dfn-for="Table/get(index)" data-dfn-type="argument" data-export="" id="dom-table-get-index-index"><code>index</code><a class="self-link" href="#dom-table-get-index-index"></a></dfn>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-table-set" id="ref-for-dom-table-set">set</a>([<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange⑦">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑨"><span class="kt">unsigned</span> <span class="kt">long</span></a> <dfn class="nv idl-code" data-dfn-for="Table/set(index, value)" data-dfn-type="argument" data-export="" id="dom-table-set-index-value-index"><code>index</code><a class="self-link" href="#dom-table-set-index-value-index"></a></dfn>, <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#Function" id="ref-for-Function①">Function</a>? <dfn class="nv idl-code" data-dfn-for="Table/set(index, value)" data-dfn-type="argument" data-export="" id="dom-table-set-index-value-value"><code>value</code><a class="self-link" href="#dom-table-set-index-value-value"></a></dfn>);
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⓪"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-table-length" id="ref-for-dom-table-length">length</a>;
+};
+</pre>
+   <div>
+     A <code class="idl"><a data-link-type="idl" href="#table" id="ref-for-table②">Table</a></code> object represents a single <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#table-instances" id="ref-for-table-instances">table instance</a> which can be simultaneously referenced by multiple <code class="idl"><a data-link-type="idl" href="#instance" id="ref-for-instance⑤">Instance</a></code> objects. Each <code class="idl"><a data-link-type="idl" href="#table" id="ref-for-table③">Table</a></code> object has the following internal slots: 
+    <ul>
+     <li data-md="">
+      <p>[[Table]] : a <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-tableaddr" id="ref-for-syntax-tableaddr①">table address</a></p>
+     <li data-md="">
+      <p>[[Values]] : a List whose elements are either null or <a data-link-type="dfn" href="#exported-function" id="ref-for-exported-function②">Exported Function</a>s.</p>
+    </ul>
+   </div>
+   <div class="algorithm" data-algorithm="create a table object">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="create-a-table-object">create a table object</dfn> from a <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-tableaddr" id="ref-for-syntax-tableaddr②">table address</a> <var>tableaddr</var>, perform the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>map</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent⑧">surrounding agent</a>'s associated <a data-link-type="dfn" href="#table-object-cache" id="ref-for-table-object-cache">Table object cache</a>.</p>
+     <li data-md="">
+      <p>If <var>map</var>[<var>tableaddr</var>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②">exists</a>,</p>
+      <ol>
+       <li data-md="">
+        <p>Return <var>map</var>[<var>tableaddr</var>].</p>
+      </ol>
+     <li data-md="">
+      <p>Let <var>values</var> be a list whose length is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-size-table" id="ref-for-embed-size-table">size_table</a>(<var>store</var>, <var>tableaddr</var>) where each element is null.</p>
+     <li data-md="">
+      <p>Let <var>table</var> be a new <code class="idl"><a data-link-type="idl" href="#table" id="ref-for-table④">Table</a></code> instance with [[Table]] set to <var>tableaddr</var> and [[Values]] set to <var>values</var>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set①">Set</a> <var>map</var>[<var>tableaddr</var>] to <var>table</var>.</p>
+     <li data-md="">
+      <p>Return <var>table</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="Table(descriptor)">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="Table" data-dfn-type="constructor" data-export="" id="dom-table-table"><code>Table(descriptor)</code></dfn> constructor, when invoked, performs the following steps: 
+    <ol>
+     <li data-md="">
+      <p>If <var>descriptor</var>["initial"] is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present" id="ref-for-dfn-present②">present</a>, let <var>n</var> be <var>descriptor</var>["initial"]; otherwise, let <var>n</var> be 0.</p>
+     <li data-md="">
+      <p>If <var>descriptor</var>["maximum"] is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present" id="ref-for-dfn-present③">present</a>, let <var>m</var> be <var>descriptor</var>["maximum"]; otherwise, let <var>m</var> be empty.</p>
+     <li data-md="">
+      <p>If <var>m</var> is not empty and <var>m</var> &lt; <var>n</var>, throw a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror" id="ref-for-sec-native-error-types-used-in-this-standard-rangeerror②">RangeError</a></code> exception.</p>
+     <li data-md="">
+      <p>Let <var>type</var> be the <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-tabletype" id="ref-for-syntax-tabletype">table type</a> {<a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-tabletype" id="ref-for-syntax-tabletype①">𝗆𝗂𝗇</a> n, <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-tabletype" id="ref-for-syntax-tabletype②">𝗆𝖺𝗑</a> <var>m</var>} <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-tabletype" id="ref-for-syntax-tabletype③">𝖺𝗇𝗒𝖿𝗎𝗇𝖼</a>.</p>
+     <li data-md="">
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent⑨">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store⑥">associated store</a>.</p>
+     <li data-md="">
+      <p>Let (<var>store</var>, <var>tableaddr</var>) be <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-alloc-table" id="ref-for-embed-alloc-table">alloc_table</a>(<var>store</var>, <var>type</var>).</p>
+     <li data-md="">
+      <p>Set the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent①⓪">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store⑦">associated store</a> to <var>store</var>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="#create-a-table-object" id="ref-for-create-a-table-object①">Create a table object</a> from the table address <var>tableaddr</var> and return the result.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="grow(d)">
+     The <dfn class="idl-code" data-dfn-for="Table" data-dfn-type="method" data-export="" id="dom-table-grow-d"><code>grow(d)</code><a class="self-link" href="#dom-table-grow-d"></a></dfn> method, when invoked, performs the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>tableaddr</var> be the Table instance’s [[Table]] internal slot.</p>
+     <li data-md="">
+      <p>Let <var>initialSize</var> be the length of the Table instance’s [[Values]] internal slot.</p>
+     <li data-md="">
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent①①">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store⑧">associated store</a>.</p>
+     <li data-md="">
+      <p>Let <var>result</var> be <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-grow-table" id="ref-for-embed-grow-table">grow_table</a>(<var>store</var>, <var>tableaddr</var>, <var>d</var>).</p>
+     <li data-md="">
+      <p>If <var>result</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error①⓪">error</a>, throw a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror" id="ref-for-sec-native-error-types-used-in-this-standard-rangeerror③">RangeError</a></code> exception.</p>
+      <p class="note" role="note"><span>Note:</span> The above exception may happen due to either insufficient memory or an invalid size parameter.</p>
+     <li data-md="">
+      <p>Set the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent①②">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store⑨">associated store</a> to <var>store</var>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append⑦">Append</a> null to the Table instance’s [[Values]] internal slot <var>d</var> times.</p>
+     <li data-md="">
+      <p>Return <var>initialSize</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="length"> The getter of the <dfn class="dfn-paneled idl-code" data-dfn-for="Table" data-dfn-type="attribute" data-export="" id="dom-table-length"><code>length</code></dfn> attribute of <code class="idl"><a data-link-type="idl" href="#table" id="ref-for-table⑤">Table</a></code> returns the length of the table’s [[Values]] internal slot. </div>
+   <div class="algorithm" data-algorithm="get(index)">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="Table" data-dfn-type="method" data-export="" id="dom-table-get"><code>get(index)</code></dfn> method, when invoked, performs the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>values</var> be the Table instance’s [[Values]] internal slot.</p>
+     <li data-md="">
+      <p>Let <var>size</var> be the length of <var>values</var>.</p>
+     <li data-md="">
+      <p>If <var>index</var> ≥ <var>size</var>, throw a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror" id="ref-for-sec-native-error-types-used-in-this-standard-rangeerror④">RangeError</a></code> exception.</p>
+     <li data-md="">
+      <p>Return <var>values</var>[<var>index</var>].</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="set(index, value)">
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="Table" data-dfn-type="method" data-export="" id="dom-table-set"><code>set(index, value)</code></dfn> method, when invoked, performs the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>tableaddr</var> be the Table instance’s [[Table]] internal slot.</p>
+     <li data-md="">
+      <p>Let <var>values</var> be the Table instance’s [[Values]] internal slot.</p>
+     <li data-md="">
+      <p>If <var>value</var> is null, let <var>funcaddr</var> be an empty <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-funcelem" id="ref-for-syntax-funcelem">function element</a>.</p>
+     <li data-md="">
+      <p>Otherwise,</p>
+      <ol>
+       <li data-md="">
+        <p>If <var>value</var> does not have a [[FunctionAddress]] internal slot, throw a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror" id="ref-for-sec-native-error-types-used-in-this-standard-typeerror③">TypeError</a></code> exception.</p>
+       <li data-md="">
+        <p>Let <var>funcaddr</var> be <var>value</var>.[[FunctionAddress]].</p>
+      </ol>
+     <li data-md="">
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent①③">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store①⓪">associated store</a>.</p>
+     <li data-md="">
+      <p>Let <var>store</var> be <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-write-table" id="ref-for-embed-write-table">write_table</a>(<var>store</var>, <var>tableaddr</var>, <var>index</var>, <var>funcaddr</var>).</p>
+     <li data-md="">
+      <p>If <var>store</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error①①">error</a>, throw a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror" id="ref-for-sec-native-error-types-used-in-this-standard-rangeerror⑤">RangeError</a></code> exception.</p>
+     <li data-md="">
+      <p>Set the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent①④">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store①①">associated store</a> to <var>store</var>.</p>
+     <li data-md="">
+      <p>Set <var>values</var>[<var>index</var>] to <var>value</var>.</p>
+     <li data-md="">
+      <p>Return undefined.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="3.5" id="exported-function-exotic-objects"><span class="secno">3.5. </span><span class="content">Exported Functions</span><a class="self-link" href="#exported-function-exotic-objects"></a></h3>
+   <p>A WebAssembly function is made available in JavaScript as an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="exported-function">Exported Function</dfn>.
+Exported Functions are <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-built-in-function-objects" id="ref-for-sec-built-in-function-objects">Built-in Function Objects</a> which are not constructors, and which have a [[FunctionAddress]] internal slot.
+This slot holds a <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-funcaddr" id="ref-for-syntax-funcaddr①">function address</a> relative to the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent①⑤">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store①②">associated store</a>.</p>
+   <div class="algorithm" data-algorithm="name of the WebAssembly function">
+     The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="name-of-the-webassembly-function">name of the WebAssembly function</dfn> <var>funcaddr</var> is found by performing the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent①⑥">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store①③">associated store</a>.</p>
+     <li data-md="">
+      <p>Let <var>funcinst</var> be <var>store</var>.𝖿𝗎𝗇𝖼𝗌[<var>funcaddr</var>].</p>
+     <li data-md="">
+      <p>If <var>funcinst</var> is of the form {𝗍𝗒𝗉𝖾 <var>functype</var>, 𝗁𝗈𝗌𝗍𝖼𝗈𝖽𝖾 <var>hostfunc</var>},</p>
+      <ol>
+       <li data-md="">
+        <p class="assertion">Assert: <var>hostfunc</var> is a JavaScript object and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable" id="ref-for-sec-iscallable①">IsCallable</a>(<var>hostfunc</var>) is true.</p>
+       <li data-md="">
+        <p>Let <var>index</var> be the <a data-link-type="dfn" href="#index-of-the-host-function" id="ref-for-index-of-the-host-function">index of the host function</a> <var>funcaddr</var>.</p>
+      </ol>
+     <li data-md="">
+      <p>Otherwise,</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>moduleinst</var> be <var>funcinst</var>.𝗆𝗈𝖽𝗎𝗅𝖾.</p>
+       <li data-md="">
+        <p class="assertion">Assert: <var>funcaddr</var> is contained in <var>moduleinst</var>.𝖿𝗎𝗇𝖼𝖺𝖽𝖽𝗋𝗌.</p>
+       <li data-md="">
+        <p>Let <var>index</var> be the index of <var>moduleinst</var>.𝖿𝗎𝗇𝖼𝖺𝖽𝖽𝗋𝗌 where <var>funcaddr</var> is found.</p>
+      </ol>
+     <li data-md="">
+      <p>Return ! <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tostring" id="ref-for-sec-tostring">ToString</a>(<var>index</var>).</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="a new Exported Function">
+     To create <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="a-new-exported-function">a new Exported Function</dfn> from a WebAssembly <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-funcaddr" id="ref-for-syntax-funcaddr②">function address</a> <var>funcaddr</var>, perform the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>map</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent①⑦">surrounding agent</a>'s associated <a data-link-type="dfn" href="#exported-function-cache" id="ref-for-exported-function-cache">Exported Function cache</a>.</p>
+     <li data-md="">
+      <p>If <var>map</var>[<var>funcaddr</var>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③">exists</a>,</p>
+      <ol>
+       <li data-md="">
+        <p>Return <var>map</var>[<var>funcaddr</var>].</p>
+      </ol>
+     <li data-md="">
+      <p>Let <var>steps</var> be "<a data-link-type="dfn" href="#call-an-exported-function" id="ref-for-call-an-exported-function">call the Exported Function</a> <var>funcaddr</var> with arguments."</p>
+     <li data-md="">
+      <p>Let <var>realm</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#current-realm" id="ref-for-current-realm">current Realm</a>.</p>
+     <li data-md="">
+      <p>Let <var>function</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-createbuiltinfunction" id="ref-for-sec-createbuiltinfunction">CreateBuiltinFunction</a>(<var>realm</var>, <var>steps</var>, <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-properties-of-the-function-prototype-object" id="ref-for-sec-properties-of-the-function-prototype-object">%FunctionPrototype%</a>, « [[FunctionAddress]]).</p>
+     <li data-md="">
+      <p>Set <var>function</var>.[[FunctionAddress]] to <var>funcaddr</var>.</p>
+     <li data-md="">
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent①⑧">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store①④">associated store</a>.</p>
+     <li data-md="">
+      <p>Let <var>functype</var> be <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-type-func" id="ref-for-embed-type-func">type_func</a>(<var>store</var>, <var>funcaddr</var>).</p>
+     <li data-md="">
+      <p>Let [<var>arguments</var>] → [<var>results</var>] be <var>functype</var>.</p>
+     <li data-md="">
+      <p>Let <var>arity</var> be the length of <var>arguments</var>.</p>
+     <li data-md="">
+      <p>Perform ! <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow" id="ref-for-sec-definepropertyorthrow">DefinePropertyOrThrow</a>(<var>function</var>, <code>"length"</code>, PropertyDescriptor {[[Value]]: <var>arity</var>, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true}).</p>
+     <li data-md="">
+      <p>Let <var>name</var> be the <a data-link-type="dfn" href="#name-of-the-webassembly-function" id="ref-for-name-of-the-webassembly-function">name of the WebAssembly function</a> <var>funcaddr</var>.</p>
+     <li data-md="">
+      <p>Perform ! <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-setfunctionname" id="ref-for-sec-setfunctionname">SetFunctionName</a>(<var>function</var>, <var>name</var>).</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set②">Set</a> <var>map</var>[<var>funcaddr</var>] to <var>function</var>.</p>
+     <li data-md="">
+      <p>Return <var>function</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="call an Exported Function">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="call-an-exported-function">call an Exported Function</dfn> with <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-funcaddr" id="ref-for-syntax-funcaddr③">function address</a> <var>funcaddr</var> and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list④">list</a> of JavaScript arguments <var>argValues</var>, perform the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent①⑨">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store①⑤">associated store</a>.</p>
+     <li data-md="">
+      <p>Let <var>functype</var> be <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-type-func" id="ref-for-embed-type-func①">type_func</a>(<var>store</var>, <var>funcaddr</var>).</p>
+     <li data-md="">
+      <p>Let [<var>parameters</var>] → [<var>results</var>] be <var>functype</var>.</p>
+     <li data-md="">
+      <p>If <var>parameters</var> or <var>results</var> contains an <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-valtype" id="ref-for-syntax-valtype②">𝗂𝟨𝟦</a>, throw a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror" id="ref-for-sec-native-error-types-used-in-this-standard-typeerror④">TypeError</a></code>.</p>
+      <p class="note" role="note"><span>Note:</span> the above error is thrown each time the [[Call]] method is invoked.</p>
+     <li data-md="">
+      <p>Let <var>args</var> be an empty list of WebAssembly values.</p>
+     <li data-md="">
+      <p>Let <var>i</var> be 0.</p>
+     <li data-md="">
+      <p>For each type <var>t</var> of <var>parameters</var>,</p>
+      <ol>
+       <li data-md="">
+        <p>If the length of <var>argValues</var> > <var>i</var>, let <var>arg</var> be <var>argValues</var>[i].</p>
+       <li data-md="">
+        <p>Otherwise, let <var>arg</var> be undefined.</p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append⑧">Append</a> <a data-link-type="dfn" href="#towebassemblyvalue" id="ref-for-towebassemblyvalue①">ToWebAssemblyValue</a>(<var>arg</var>, <var>t</var>) to <var>args</var>.</p>
+       <li data-md="">
+        <p>Set <var>i</var> to <var>i</var> + 1.</p>
+      </ol>
+     <li data-md="">
+      <p>Let (<var>store</var>, <var>ret</var>) be the result of <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-invoke-func" id="ref-for-embed-invoke-func">invoke_func</a>(<var>store</var>, <var>funcaddr</var>, <var>args</var>).</p>
+     <li data-md="">
+      <p>Set the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent②⓪">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store①⑥">associated store</a> to <var>store</var>.</p>
+     <li data-md="">
+      <p>If <var>ret</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error①②">error</a>, throw an exception. This exception should be a WebAssembly <code class="idl"><a data-link-type="idl" href="#runtimeerror" id="ref-for-runtimeerror①">RuntimeError</a></code> exception, unless otherwise indicated by <a href="#errors">the WebAssembly error mapping</a>.</p>
+     <li data-md="">
+      <p>If <var>outArity</var> is 0, return undefined.</p>
+     <li data-md="">
+      <p>Otherwise, return <a data-link-type="dfn" href="#tojsvalue" id="ref-for-tojsvalue①">ToJSValue</a>(<var>v</var>), where <var>v</var> is the singular element of <var>ret</var>.</p>
+    </ol>
+   </div>
+   <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="#call-an-exported-function" id="ref-for-call-an-exported-function①">Calling an Exported Function</a> executes in the [[Realm]] of the callee Exported Function, as per the definition of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-built-in-function-objects" id="ref-for-sec-built-in-function-objects①">built-in function objects</a>.</p>
+   <p class="note" role="note"><span>Note:</span> Exported Functions do not have a [[Construct]] method and thus it is not possible to call one with the <code>new</code> operator.</p>
+   <div class="algorithm" data-algorithm="create a host function">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="create-a-host-function">create a host function</dfn> from the JavaScript object <var>func</var>, perform the following steps: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>hostfunc</var> be a <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-hostfunc" id="ref-for-syntax-hostfunc">host function</a> which performs the following steps when called:</p>
+      <ol>
+       <li data-md="">
+        <p>If the signature contains an <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-valtype" id="ref-for-syntax-valtype③">𝗂𝟨𝟦</a> (as argument or result), the host function throws a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror" id="ref-for-sec-native-error-types-used-in-this-standard-typeerror⑤">TypeError</a></code> when called.</p>
+       <li data-md="">
+        <p>Let <var>arguments</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑤">list</a> of the arguments of the invocation of this function.</p>
+       <li data-md="">
+        <p>Let <var>jsArguments</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑥">list</a>.</p>
+       <li data-md="">
+        <p>For each <var>arg</var> in <var>arguments</var>,</p>
+        <ol>
+         <li data-md="">
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append⑨">Append</a> <a data-link-type="dfn" href="#tojsvalue" id="ref-for-tojsvalue②">ToJSValue</a>(<var>arg</var>) to <var>jsArguments</var>.</p>
+        </ol>
+       <li data-md="">
+        <p>Let <var>ret</var> be ? <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-call" id="ref-for-sec-call">Call</a>(<var>func</var>, undefined, <var>jsArguments</var>). If an exception is thrown, trigger a WebAssembly trap, and propagate the exception to the enclosing JavaScript.</p>
+       <li data-md="">
+        <p>Let [<var>parameters</var>] → [<var>results</var>] be <var>functype</var>.</p>
+       <li data-md="">
+        <p>If <var>results</var> is empty, return undefined.</p>
+       <li data-md="">
+        <p>Otherwise, return <a data-link-type="dfn" href="#towebassemblyvalue" id="ref-for-towebassemblyvalue②">ToWebAssemblyValue</a>(<var>ret</var>, <var>results</var>[0]).</p>
+      </ol>
+     <li data-md="">
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent②①">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store①⑦">associated store</a>.</p>
+     <li data-md="">
+      <p>Let (<var>store</var>, <var>funcaddr</var>) be <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-alloc-func" id="ref-for-embed-alloc-func">alloc_func</a>(<var>store</var>, <var>functype</var>, <var>hostfunc</var>).</p>
+     <li data-md="">
+      <p>Set the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#surrounding-agent" id="ref-for-surrounding-agent②②">surrounding agent</a>'s <a data-link-type="dfn" href="#associated-store" id="ref-for-associated-store①⑧">associated store</a> to <var>store</var>.</p>
+     <li data-md="">
+      <p>Return <var>funcaddr</var></p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="ToJSValue">
+     The algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="tojsvalue">ToJSValue</dfn>(<var>w</var>) coerces a <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#values" id="ref-for-values①">WebAssembly value</a> to a JavaScript value performs the following steps: 
+    <p class="assertion">Assert: <var>w</var> is not of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#values" id="ref-for-values②">𝗂𝟨𝟦.𝖼𝗈𝗇𝗌𝗍</a> <var>i64</var>.</p>
+    <ol>
+     <li data-md="">
+      <p>If <var>w</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#values" id="ref-for-values③">𝗂𝟥𝟤.𝖼𝗈𝗇𝗌𝗍</a> <var>i32</var>, return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type" id="ref-for-sec-ecmascript-language-types-number-type">the Number value</a> for <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/numerics.html#aux-signed" id="ref-for-aux-signed">signed_32</a>(<var>i32</var>).</p>
+     <li data-md="">
+      <p>If <var>w</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#values" id="ref-for-values④">𝖿𝟥𝟤.𝖼𝗈𝗇𝗌𝗍</a> <var>f32</var>, return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type" id="ref-for-sec-ecmascript-language-types-number-type①">the Number value</a> for <var>f32</var>.</p>
+     <li data-md="">
+      <p>If <var>w</var> is of the form <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#values" id="ref-for-values⑤">𝖿𝟨𝟦.𝖼𝗈𝗇𝗌𝗍</a> <var>f64</var>, return <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type" id="ref-for-sec-ecmascript-language-types-number-type②">the Number value</a> for <var>f64</var>.</p>
+    </ol>
+    <p class="note" role="note"><span>Note:</span> Implementations may optionally replace the NaN payload with any other NaN payload at this point in the f32 or f64 cases; such a change would not be observable through <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-numbertorawbytes" id="ref-for-sec-numbertorawbytes">NumberToRawBytes</a>.</p>
+   </div>
+   <div class="algorithm" data-algorithm="ToWebAssemblyValue">
+     The algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="towebassemblyvalue">ToWebAssemblyValue</dfn>(<var>v</var>, <var>type</var>) coerce a JavaScript value to a <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#values" id="ref-for-values⑥">WebAssembly value</a> performs the following steps: 
+    <p class="assertion">Assert: <var>type</var> is not <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-valtype" id="ref-for-syntax-valtype④">𝗂𝟨𝟦</a>.</p>
+    <ol>
+     <li data-md="">
+      <p>If <var>type</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-valtype" id="ref-for-syntax-valtype⑤">𝗂𝟥𝟤</a>,</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>i32</var> be ? <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-toint32" id="ref-for-sec-toint32">ToInt32</a>(<var>v</var>).</p>
+       <li data-md="">
+        <p>Return <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#values" id="ref-for-values⑦">𝗂𝟥𝟤.𝖼𝗈𝗇𝗌𝗍</a> <var>i32</var>.</p>
+      </ol>
+     <li data-md="">
+      <p>If <var>type</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-valtype" id="ref-for-syntax-valtype⑥">𝖿𝟥𝟤</a>,</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>f32</var> be ? <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tonumber" id="ref-for-sec-tonumber">ToNumber</a>(<var>v</var>) rounded to the nearest representable value using IEEE 754-2008 round to nearest, ties to even mode.</p>
+       <li data-md="">
+        <p>Return <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#values" id="ref-for-values⑧">𝖿𝟥𝟤.𝖼𝗈𝗇𝗌𝗍</a> <var>f32</var>.</p>
+      </ol>
+     <li data-md="">
+      <p>If <var>type</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-valtype" id="ref-for-syntax-valtype⑦">𝖿𝟨𝟦</a>,</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>f64</var> be ? <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-tonumber" id="ref-for-sec-tonumber①">ToNumber</a>(<var>v</var>).</p>
+       <li data-md="">
+        <p>Return <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/exec/runtime.html#values" id="ref-for-values⑨">𝖿𝟨𝟦.𝖼𝗈𝗇𝗌𝗍</a> <var>f64</var>.</p>
+      </ol>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="3.6" id="error-objects"><span class="secno">3.6. </span><span class="content">Error Objects</span><a class="self-link" href="#error-objects"></a></h3>
+   <p>WebAssembly defines the following Error classes: <code class="idl"><a data-link-type="idl" href="#compileerror" id="ref-for-compileerror②">CompileError</a></code>, <code class="idl"><a data-link-type="idl" href="#linkerror" id="ref-for-linkerror⑥">LinkError</a></code>, and <code class="idl"><a data-link-type="idl" href="#runtimeerror" id="ref-for-runtimeerror②">RuntimeError</a></code>. WebAssembly errors have the following custom bindings:</p>
+   <ul>
+    <li data-md="">
+     <p>Unlike normal interface types, the interface prototype object for these exception classes must have as its [[Prototype]] the intrinsic object <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects" id="ref-for-sec-well-known-intrinsic-objects">%ErrorPrototype%</a>.</p>
+    <li data-md="">
+     <p>The constructor and properties of WebAssembly errors is as specified for <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-nativeerror-constructors" id="ref-for-sec-nativeerror-constructors">NativeError</a></code>.</p>
+    <li data-md="">
+     <p>If an implementation gives native Error objects special powers or nonstandard properties (such as a stack property), it should also expose those on these exception instances.</p>
+   </ul>
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace④">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly④">WebAssembly</a>]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="compileerror"><code>CompileError</code></dfn> { };
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace⑤">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly⑤">WebAssembly</a>]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="linkerror"><code>LinkError</code></dfn> { };
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace⑥">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly⑥">WebAssembly</a>]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="runtimeerror"><code>RuntimeError</code></dfn> { };
+</pre>
+   <h2 class="heading settled" data-level="4" id="errors"><span class="secno">4. </span><span class="content">Error Condition Mappings to JavaScript</span><a class="self-link" href="#errors"></a></h2>
+   <p>Running WebAssembly programs encounter certain events which halt execution of the WebAssembly code.
+WebAssembly code (currently)
+has no way to catch these conditions and thus an exception will necessarily
+propagate to the enclosing non-WebAssembly caller (whether it is a browser,
+JavaScript or another runtime system) where it is handled like a normal JavaScript exception.</p>
+   <p>If WebAssembly calls JavaScript via import and the JavaScript throws an
+exception, the exception is propagated through the WebAssembly activation to the
+enclosing caller.</p>
+   <p>Because JavaScript exceptions can be handled, and JavaScript can continue to
+call WebAssembly exports after a trap has been handled, traps do not, in
+general, prevent future execution.</p>
+   <h3 class="heading settled" data-level="4.1" id="stack-overflow"><span class="secno">4.1. </span><span class="content">Stack Overflow</span><a class="self-link" href="#stack-overflow"></a></h3>
+   <p>Whenever a stack overflow occurs in
+WebAssembly code, the same class of exception is thrown as for a stack overflow in
+JavaScript. The particular exception here is implementation-defined in both cases.</p>
+   <p class="note" role="note"><span>Note:</span> ECMAScript doesn’t specify any sort of behavior on stack overflow; implementations have been observed to throw <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror" id="ref-for-sec-native-error-types-used-in-this-standard-rangeerror⑥">RangeError</a></code>, InternalError or Error. Any is valid here.</p>
+   <h3 class="heading settled" data-level="4.2" id="out-of-memory"><span class="secno">4.2. </span><span class="content">Out of Memory</span><a class="self-link" href="#out-of-memory"></a></h3>
+   <p>Whenever validation, compilation or instantiation run out of memory, the
+same class of exception is thrown as for out of memory conditions in JavaScript.
+The particular exception here is implementation-defined in both cases.</p>
+   <p class="note" role="note"><span>Note:</span> ECMAScript doesn’t specify any sort of behavior on out-of-memory conditions; implementations have been observed to throw OOMError and to crash. Either is valid here.</p>
+   <h2 class="heading settled" data-level="5" id="esm-integration"><span class="secno">5. </span><span class="content">Integration with ECMAScript modules</span><a class="self-link" href="#esm-integration"></a></h2>
+   <p>WebAssembly modules can be used in a module graph with ECMAScript modules.</p>
+   <p><dfn data-dfn-type="dfn" data-noexport="" id="webassembly-module-record">WebAssembly Module Record<a class="self-link" href="#webassembly-module-record"></a></dfn>s are a subclass of <a href="https://github.com/tc39/ecma262/pull/1311">Circular Module Records</a> which contain WebAssembly code. WebAssembly Module Records has one additional internal slot:</p>
+   <ul>
+    <li data-md="">
+     <p>[[WebAssemblyModule]] : a WebAssembly <code class="idl"><a data-link-type="idl" href="#module" id="ref-for-module①①">Module</a></code> object</p>
+   </ul>
+   <div class="algorithm" data-algorithm="parse a WebAssembly module">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="parse-a-webassembly-module">parse a WebAssembly module</dfn> given a an <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects" id="ref-for-sec-arraybuffer-objects⑧">ArrayBuffer</a></code> <var>body</var>, a Realm <var>realm</var> and object <var>hostDefined</var>, perform the following steps. 
+    <ol>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="#compile-a-webassembly-module" id="ref-for-compile-a-webassembly-module③">Compile the WebAssembly module</a> <var>stableBytes</var> and store the result as <var>module</var>.</p>
+     <li data-md="">
+      <p>If <var>module</var> is <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error" id="ref-for-embed-error①③">error</a>, throw a <code class="idl"><a data-link-type="idl" href="#compileerror" id="ref-for-compileerror③">CompileError</a></code> exception.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="#construct-a-webassembly-module-object" id="ref-for-construct-a-webassembly-module-object②">Construct a WebAssembly module object</a> from <var>module</var> and <var>bytes</var>, and let <var>module</var> be the result.</p>
+     <li data-md="">
+      <p>Let <var>requestedModules</var> be a set.</p>
+     <li data-md="">
+      <p>For each (<var>moduleName</var>, <var>name</var>, <var>type</var>) in <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-imports" id="ref-for-embed-imports②">module_imports</a>(<var>module</var>.[[Module]]),</p>
+      <ol>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append①⓪">Append</a> <var>moduleName</var> to <var>requestedModules</var>.</p>
+      </ol>
+     <li data-md="">
+      <p>Return { [[Realm]]: <var>realm</var>, [[Environment]]: undefined, [[Namespace]]: undefined, [[Status]]: "uninstantiated", [[EvaluationError]]: undefined, [[HostDefined]]: <var>hostDefined</var>, [[WebAssemblyModule]]: <var>module</var>, [[RequestedModules]]: <var>requestedModules</var>, [[DFSIndex]]: undefined, [[DFSAncestorIndex]]: undefined }.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="export name list">
+     The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="export-name-list">export name list</dfn> of a WebAssembly Module Record <var>record</var> is defined by the following algorithm: 
+    <ol>
+     <li data-md="">
+      <p>Let <var>module</var> be <var>record</var>’s [[WebAssemblyModule]] internal slot.</p>
+     <li data-md="">
+      <p>Let <var>exports</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑦">list</a>.</p>
+     <li data-md="">
+      <p>For each (<var>name</var>, <var>type</var>) in <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-exports" id="ref-for-embed-exports②">module_exports</a>(<var>module</var>.[[Module]])</p>
+      <ol>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append①①">Append</a> <var>name</var> to the end of <var>exports</var>.</p>
+      </ol>
+     <li data-md="">
+      <p>Return <var>exports</var>.</p>
+    </ol>
+   </div>
+   <p>WebAssembly Module Records have the following methods:</p>
+   <h3 class="heading settled" data-level="5.1" id="get-exported-names"><span class="secno">5.1. </span><span class="content">GetExportedNames ( <var>exportStarSet</var> ) Concrete Method</span><a class="self-link" href="#get-exported-names"></a></h3>
+   <ol>
+    <li data-md="">
+     <p>Let <var>record</var> be this WebAssembly Module Record.</p>
+    <li data-md="">
+     <p>Return the <a data-link-type="dfn" href="#export-name-list" id="ref-for-export-name-list">export name list</a> of <var>record</var>.</p>
+   </ol>
+   <h3 class="heading settled" data-level="5.2" id="resolve-export"><span class="secno">5.2. </span><span class="content">ResolveExport ( <var>exportName</var>, <var>resolveSet</var> ) Concrete Method</span><a class="self-link" href="#resolve-export"></a></h3>
+   <ol>
+    <li data-md="">
+     <p>Let <var>record</var> be this WebAssembly Module Record.</p>
+    <li data-md="">
+     <p>If the <a data-link-type="dfn" href="#export-name-list" id="ref-for-export-name-list①">export name list</a> of <var>record</var> contains <var>exportName</var>, return { [[Module]]: <var>record</var>, [[BindingName]]: <var>exportName</var> }.</p>
+    <li data-md="">
+     <p>Otherwise, return null.</p>
+   </ol>
+   <h3 class="heading settled" data-level="5.3" id="module-declaration-environment-setup"><span class="secno">5.3. </span><span class="content">ModuleDeclarationEnvironmentSetup ( ) Concrete Method</span><a class="self-link" href="#module-declaration-environment-setup"></a></h3>
+   <ol>
+    <li data-md="">
+     <p>Let <var>record</var> be this WebAssembly Module Record.</p>
+    <li data-md="">
+     <p>Let <var>env</var> be NewModuleEnvironment(null).</p>
+    <li data-md="">
+     <p>Set <var>record</var>.[[Environment]] to <var>env</var>.</p>
+    <li data-md="">
+     <p>Let <var>envRec</var> be <var>env</var>’s EnvironmentRecord.</p>
+    <li data-md="">
+     <p>For each <var>name</var> in the <a data-link-type="dfn" href="#export-name-list" id="ref-for-export-name-list②">export name list</a> of <var>record</var>,</p>
+     <ol>
+      <li data-md="">
+       <p>Perform ! <var>envRec</var>.CreateImmutableBinding(<var>name</var>, true).</p>
+     </ol>
+   </ol>
+   <h3 class="heading settled" data-level="5.4" id="module-execution"><span class="secno">5.4. </span><span class="content">ModuleExecution ( ) Concrete Method</span><a class="self-link" href="#module-execution"></a></h3>
+   <ol>
+    <li data-md="">
+     <p>Let <var>record</var> be this WebAssembly Module Record.</p>
+    <li data-md="">
+     <p>Let <var>module</var> be <var>record</var>.[[WebAssemblyModule]].</p>
+    <li data-md="">
+     <p>Let <var>imports</var> be a new, empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map①">map</a>.</p>
+    <li data-md="">
+     <p>For each (<var>importedModuleName</var>, <var>name</var>, <var>type</var>) in <a data-link-type="dfn" href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-imports" id="ref-for-embed-imports③">module_imports</a>(<var>module</var>.[[Module]]),</p>
+     <ol>
+      <li data-md="">
+       <p>If <var>imports</var>[<var>importedModuleName</var>] does not exist, set <var>imports</var>[<var>importedModuleName</var>] to a new, empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map②">map</a>.</p>
+      <li data-md="">
+       <p>Let <var>importedModule</var> be ! HostResolveImportedModule(<var>module</var>, <var>importedModuleName</var>).</p>
+      <li data-md="">
+       <p class="note" role="note"><span>NOTE:</span> The above call cannot fail because imported module requests are a subset of <var>module</var>.[[RequestedModules]], and these have been resolved earlier in this algorithm.</p>
+      <li data-md="">
+       <p>Let <var>value</var> be ? <var>importedModule</var>.[[Environment]].GetBindingValue(<var>name</var>, true).</p>
+      <li data-md="">
+       <p>Set <var>imports</var>[<var>moduleName</var>][<var>name</var>] to <var>value</var>.</p>
+     </ol>
+    <li data-md="">
+     <p>Let <var>importsObject</var> be a new Object.</p>
+    <li data-md="">
+     <p>For each <var>key</var> → <var>value</var> of <var>imports</var>,</p>
+     <ol>
+      <li data-md="">
+       <p>Let <var>moduleImportsObject</var> be a new Object.</p>
+      <li data-md="">
+       <p>For each <var>importedName</var> → <var>importedValue</var> of <var>imports</var>,</p>
+       <ol>
+        <li data-md="">
+         <p>Perform ! CreateDataPropertyOrThrow(<var>moduleImportsObject</var>, <var>importedName</var>, <var>importedValuealue</var>).</p>
+       </ol>
+      <li data-md="">
+       <p>Perform ! CreateDataPropertyOrThrow(<var>importsObject</var>, <var>key</var>, <var>moduleImportsObject</var>).</p>
+     </ol>
+    <li data-md="">
+     <p><a data-link-type="dfn" href="#instantiate-a-webassembly-module" id="ref-for-instantiate-a-webassembly-module③">Instantiate a WebAssembly module</a> <var>module</var> with imports <var>importsObject</var> and let <var>instance</var> be the result.</p>
+    <li data-md="">
+     <p>Let <var>envRec</var> be the EnvironmentRecord of <var>record</var>.[[Environment]].</p>
+    <li data-md="">
+     <p>For each <var>name</var> in the <a data-link-type="dfn" href="#export-name-list" id="ref-for-export-name-list③">export name list</a> of <var>record</var>,</p>
+     <ol>
+      <li data-md="">
+       <p>Perform ! <var>envRec</var>.InitializeBinding(<var>name</var>, ! Get(<var>instance</var>.[[Exports]], <var>name</var>)).</p>
+     </ol>
+   </ol>
+   <p class="note" role="note"><span>Note:</span> Instantiating the WebAssembly module may yield to the task queue and is not guaranteed to be synchronous.</p>
+   <h3 class="heading settled" data-level="5.5" id="html-modifications"><span class="secno">5.5. </span><span class="content">Modifications to HTML</span><a class="self-link" href="#html-modifications"></a></h3>
+   <p>The <a href="https://html.spec.whatwg.org/#fetch-a-single-module-script">fetch a single module script</a> algorithm, in Step 9, would switch off of the mimetype. If the response has a JavaScript mimetype, continue the algorithm. If it has a non-wasm mimetype, abort the algorithm. If it has an <code>application/wasm</code> mimetype, perform the following steps:</p>
+   <ol>
+    <li data-md="">
+     <p>Let <var>source</var> be <var>response</var>’s body as an <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects" id="ref-for-sec-arraybuffer-objects⑨">ArrayBuffer</a></code></p>
+    <li data-md="">
+     <p><a href="https://html.spec.whatwg.org/#creating-a-module-script">Create a module script</a>, but with step 7 replacing ParseModule with the <a data-link-type="dfn" href="#parse-a-webassembly-module" id="ref-for-parse-a-webassembly-module">parse a WebAssembly Module</a> algorithm.</p>
+    <li data-md="">
+     <p>Set <var>moduleMap</var>[<var>url</var>] to to <var>module</var></p>
+   </ol>
+   <p>TODO: Write this up as a PR against the HTML spec.</p>
+  </main>
+  <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
+  <h3 class="heading settled" id="document-conventions"><span class="content"> Document conventions</span><a class="self-link" href="#document-conventions"></a></h3>
+  <p>Conformance requirements are expressed with a combination of
+	descriptive assertions and RFC 2119 terminology. The key words “MUST”,
+	“MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”,
+	“RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative parts of this
+	document are to be interpreted as described in RFC 2119.
+	However, for readability, these words do not appear in all uppercase
+	letters in this specification. </p>
+  <p>All of the text of this specification is normative except sections
+	explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
+  <p>Examples in this specification are introduced with the words “for example”
+	or are set apart from the normative text with <code>class="example"</code>,
+	like this: </p>
+  <div class="example" id="example-52448c84">
+   <a class="self-link" href="#example-52448c84"></a> 
+   <p>This is an example of an informative example. </p>
+  </div>
+  <p>Informative notes begin with the word “Note” and are set apart from the
+	normative text with <code>class="note"</code>, like this: </p>
+  <p class="note" role="note">
+   Note, this is an informative note. 
+<script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+  </p>
+  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="index">
+   <li><a href="#a-new-exported-function">a new Exported Function</a><span>, in §3.5</span>
+   <li><a href="#dom-tablekind-anyfunc">"anyfunc"</a><span>, in §3.4</span>
+   <li><a href="#dom-tablekind-anyfunc">anyfunc</a><span>, in §3.4</span>
+   <li><a href="#associated-store">associated store</a><span>, in §2.1</span>
+   <li><a href="#asynchronously-compile-a-webassembly-module">asynchronously compile a WebAssembly module</a><span>, in §3</span>
+   <li><a href="#dom-memory-buffer">buffer</a><span>, in §3.3</span>
+   <li><a href="#call-an-exported-function">call an Exported Function</a><span>, in §3.5</span>
+   <li><a href="#compile-a-webassembly-module">compile a WebAssembly module</a><span>, in §3</span>
+   <li><a href="#dom-webassembly-compile">compile(bytes)</a><span>, in §3</span>
+   <li><a href="#compileerror">CompileError</a><span>, in §3.6</span>
+   <li><a href="#construct-a-webassembly-module-object">construct a WebAssembly module object</a><span>, in §3</span>
+   <li><a href="#create-a-host-function">create a host function</a><span>, in §3.5</span>
+   <li><a href="#create-a-memory-object">create a memory object</a><span>, in §3.3</span>
+   <li><a href="#create-a-table-object">create a table object</a><span>, in §3.4</span>
+   <li><a href="#dom-module-customsections-moduleobject-sectionname">customSections(moduleObject, sectionName)</a><span>, in §3.1</span>
+   <li><a href="#dom-module-customsections">customSections(module, sectionName)</a><span>, in §3.1</span>
+   <li><a href="#dom-tabledescriptor-element">element</a><span>, in §3.4</span>
+   <li><a href="#exported-function">Exported Function</a><span>, in §3.5</span>
+   <li><a href="#exported-function-cache">Exported Function cache</a><span>, in §2.2</span>
+   <li><a href="#export-name-list">export name list</a><span>, in §5</span>
+   <li><a href="#dom-instance-exports">exports</a><span>, in §3.2</span>
+   <li><a href="#dom-module-exports">exports(module)</a><span>, in §3.1</span>
+   <li><a href="#dom-module-exports-moduleobject">exports(moduleObject)</a><span>, in §3.1</span>
+   <li><a href="#dom-importexportkind-function">"function"</a><span>, in §3.1</span>
+   <li><a href="#dom-importexportkind-function">function</a><span>, in §3.1</span>
+   <li><a href="#dom-table-get">get(index)</a><span>, in §3.4</span>
+   <li><a href="#dom-importexportkind-global">global</a><span>, in §3.1</span>
+   <li><a href="#dom-importexportkind-global">"global"</a><span>, in §3.1</span>
+   <li><a href="#dom-table-grow-d">grow(d)</a><span>, in §3.4</span>
+   <li>
+    grow(delta)
+    <ul>
+     <li><a href="#dom-memory-grow">method for Memory</a><span>, in §3.3</span>
+     <li><a href="#dom-table-grow">method for Table</a><span>, in §3.4</span>
+    </ul>
+   <li><a href="#identified-with">identified with</a><span>, in §2.1</span>
+   <li><a href="#enumdef-importexportkind">ImportExportKind</a><span>, in §3.1</span>
+   <li><a href="#dom-module-imports">imports(module)</a><span>, in §3.1</span>
+   <li><a href="#dom-module-imports-moduleobject">imports(moduleObject)</a><span>, in §3.1</span>
+   <li><a href="#index-of-the-host-function">index of the host function</a><span>, in §3</span>
+   <li>
+    initial
+    <ul>
+     <li><a href="#dom-memorydescriptor-initial">dict-member for MemoryDescriptor</a><span>, in §3.3</span>
+     <li><a href="#dom-tabledescriptor-initial">dict-member for TableDescriptor</a><span>, in §3.4</span>
+    </ul>
+   <li><a href="#instance">Instance</a><span>, in §3.2</span>
+   <li><a href="#dom-webassemblyinstantiatedsource-instance">instance</a><span>, in §3</span>
+   <li><a href="#dom-instance-instance">Instance(module, importObject)</a><span>, in §3.2</span>
+   <li><a href="#instantiate-a-promise-of-a-module">instantiate a promise of a module</a><span>, in §3</span>
+   <li><a href="#instantiate-a-webassembly-module">instantiate a WebAssembly module</a><span>, in §3</span>
+   <li><a href="#dom-webassembly-instantiate">instantiate(bytes)</a><span>, in §3</span>
+   <li><a href="#dom-webassembly-instantiate">instantiate(bytes, importObject)</a><span>, in §3</span>
+   <li><a href="#dom-webassembly-instantiate-moduleobject-importobject">instantiate(moduleObject)</a><span>, in §3</span>
+   <li><a href="#dom-webassembly-instantiate-moduleobject-importobject">instantiate(moduleObject, importObject)</a><span>, in §3</span>
+   <li>
+    kind
+    <ul>
+     <li><a href="#dom-moduleexportdescriptor-kind">dict-member for ModuleExportDescriptor</a><span>, in §3.1</span>
+     <li><a href="#dom-moduleimportdescriptor-kind">dict-member for ModuleImportDescriptor</a><span>, in §3.1</span>
+    </ul>
+   <li><a href="#dom-table-length">length</a><span>, in §3.4</span>
+   <li><a href="#linkerror">LinkError</a><span>, in §3.6</span>
+   <li>
+    maximum
+    <ul>
+     <li><a href="#dom-memorydescriptor-maximum">dict-member for MemoryDescriptor</a><span>, in §3.3</span>
+     <li><a href="#dom-tabledescriptor-maximum">dict-member for TableDescriptor</a><span>, in §3.4</span>
+    </ul>
+   <li><a href="#dom-importexportkind-memory">"memory"</a><span>, in §3.1</span>
+   <li><a href="#dom-importexportkind-memory">memory</a><span>, in §3.1</span>
+   <li><a href="#memory">Memory</a><span>, in §3.3</span>
+   <li><a href="#dictdef-memorydescriptor">MemoryDescriptor</a><span>, in §3.3</span>
+   <li><a href="#dom-memory-memory">Memory(descriptor)</a><span>, in §3.3</span>
+   <li><a href="#memory-object-cache">Memory object cache</a><span>, in §2.2</span>
+   <li>
+    module
+    <ul>
+     <li><a href="#dom-webassemblyinstantiatedsource-module">dict-member for WebAssemblyInstantiatedSource</a><span>, in §3</span>
+     <li><a href="#dom-moduleimportdescriptor-module">dict-member for ModuleImportDescriptor</a><span>, in §3.1</span>
+    </ul>
+   <li><a href="#module">Module</a><span>, in §3.1</span>
+   <li><a href="#dom-module-module">Module(bytes)</a><span>, in §3.1</span>
+   <li><a href="#dictdef-moduleexportdescriptor">ModuleExportDescriptor</a><span>, in §3.1</span>
+   <li><a href="#dictdef-moduleimportdescriptor">ModuleImportDescriptor</a><span>, in §3.1</span>
+   <li>
+    name
+    <ul>
+     <li><a href="#dom-moduleexportdescriptor-name">dict-member for ModuleExportDescriptor</a><span>, in §3.1</span>
+     <li><a href="#dom-moduleimportdescriptor-name">dict-member for ModuleImportDescriptor</a><span>, in §3.1</span>
+    </ul>
+   <li><a href="#name-of-the-webassembly-function">name of the WebAssembly function</a><span>, in §3.5</span>
+   <li><a href="#parse-a-webassembly-module">parse a WebAssembly module</a><span>, in §5</span>
+   <li><a href="#reset-the-memory-buffer">reset the Memory buffer</a><span>, in §3.3</span>
+   <li><a href="#runtimeerror">RuntimeError</a><span>, in §3.6</span>
+   <li><a href="#dom-table-set">set(index, value)</a><span>, in §3.4</span>
+   <li><a href="#string-value-of-the-extern-type">string value of the extern type</a><span>, in §3.1</span>
+   <li><a href="#dom-importexportkind-table">table</a><span>, in §3.1</span>
+   <li><a href="#dom-importexportkind-table">"table"</a><span>, in §3.1</span>
+   <li><a href="#table">Table</a><span>, in §3.4</span>
+   <li><a href="#dom-table-table">Table(descriptor)</a><span>, in §3.4</span>
+   <li><a href="#dictdef-tabledescriptor">TableDescriptor</a><span>, in §3.4</span>
+   <li><a href="#enumdef-tablekind">TableKind</a><span>, in §3.4</span>
+   <li><a href="#table-object-cache">Table object cache</a><span>, in §2.2</span>
+   <li><a href="#tojsvalue">ToJSValue</a><span>, in §3.5</span>
+   <li><a href="#towebassemblyvalue">ToWebAssemblyValue</a><span>, in §3.5</span>
+   <li><a href="#dom-webassembly-validate">validate(bytes)</a><span>, in §3</span>
+   <li><a href="#namespacedef-webassembly">WebAssembly</a><span>, in §3</span>
+   <li><a href="#dictdef-webassemblyinstantiatedsource">WebAssemblyInstantiatedSource</a><span>, in §3</span>
+   <li><a href="#webassembly-module-record">WebAssembly Module Record</a><span>, in §5</span>
+  </ul>
+  <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="index">
+   <li>
+    <a data-link-type="biblio">[css-values-3]</a> defines the following terms:
+    <ul>
+     <li><a href="https://drafts.csswg.org/css-values-4/#number">number</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[ECMASCRIPT]</a> defines the following terms:
+    <ul>
+     <li><a href="https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects">%errorprototype%</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-function-prototype-object">%functionprototype%</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects">ArrayBuffer</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-nativeerror-constructors">NativeError</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror">RangeError</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a>
+     <li><a href="https://tc39.github.io/ecma262/#agent">agent</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-agent-clusters">agent cluster</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">built-in function objects</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-call">call</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-createbuiltinfunction">createbuiltinfunction</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-createdataproperty">createdataproperty</a>
+     <li><a href="https://tc39.github.io/ecma262/#current-realm">current realm</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-data-blocks">data block</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">definepropertyorthrow</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">detacharraybuffer</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-get-o-p">get</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-iscallable">iscallable</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-numbertorawbytes">numbertorawbytes</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-objectcreate">objectcreate</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-setfunctionname">setfunctionname</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-setintegritylevel">setintegritylevel</a>
+     <li><a href="https://tc39.github.io/ecma262/#surrounding-agent">surrounding agent</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">the number value</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-toint32">toint32</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-tonumber">tonumber</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-tostring">tostring</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">type</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[ENCODING]</a> defines the following terms:
+    <ul>
+     <li><a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom-or-fail">utf-8 decode without bom or fail</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
+    <ul>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
+    <ul>
+     <li><a href="https://infra.spec.whatwg.org/#set-append">append</a>
+     <li><a href="https://infra.spec.whatwg.org/#map-exists">exist</a>
+     <li><a href="https://infra.spec.whatwg.org/#list">list</a>
+     <li><a href="https://infra.spec.whatwg.org/#ordered-map">map</a>
+     <li><a href="https://infra.spec.whatwg.org/#ordered-map">ordered map</a>
+     <li><a href="https://infra.spec.whatwg.org/#map-set">set</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[promises-guide]</a> defines the following terms:
+    <ul>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise">reject</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise">resolve</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">upon fulfillment</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">upon rejection</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[URL]</a> defines the following terms:
+    <ul>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-object">object</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[WEBASSEMBLY]</a> defines the following terms:
+    <ul>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#addresses">address</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-alloc-func">alloc_func</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-alloc-global">alloc_global</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-alloc-mem">alloc_mem</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-alloc-table">alloc_table</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/conventions.html#exec-notation-textual">current frame</a>
+     <li><a href="https://webassembly.github.io/spec/core/binary/modules.html#custom-section">custom section</a>
+     <li><a href="https://webassembly.github.io/spec/core/binary/modules.html#binary-customsec">customsec</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-decode-module">decode_module</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-error">error</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval">external value</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-funcaddr">function address</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-funcelem">function element</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-get-export">get_export</a>
+     <li><a href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-globaltype">global type</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-grow-mem">grow_mem</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/instructions.html#exec-grow-memory">grow_memory</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-grow-table">grow_table</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-hostfunc">host function</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-init-store">init_store</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-instantiate-module">instantiate_module</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-invoke-func">invoke_func</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-memaddr">memory address</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#memory-instances">memory instance</a>
+     <li><a href="https://webassembly.github.io/spec/core/syntax/modules.html#syntax-module">module</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-exports">module_exports</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-imports">module_imports</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-read-global">read_global</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/numerics.html#aux-signed">signed_32</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-size-mem">size_mem</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-size-table">size_table</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-store">store</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-tableaddr">table address</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#table-instances">table instance</a>
+     <li><a href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-tabletype">table type</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-type-func">type_func</a>
+     <li><a href="https://webassembly.github.io/spec/core/valid/modules.html#valid-module">valid</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-validate-module">validate_module</a>
+     <li><a href="https://webassembly.github.io/spec/core/valid/modules.html#valid-module">webassembly module validation</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#values">webassembly value</a>
+     <li><a href="https://webassembly.github.io/spec/core/appendix/embedding.html#embed-write-table">write_table</a>
+     <li><a href="https://webassembly.github.io/spec/core/syntax/types.html#external-types">𝖿𝗎𝗇𝖼</a>
+     <li><a href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-valtype">𝖿𝟥𝟤</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#values">𝖿𝟥𝟤.𝖼𝗈𝗇𝗌𝗍</a>
+     <li><a href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-valtype">𝖿𝟨𝟦</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#values">𝖿𝟨𝟦.𝖼𝗈𝗇𝗌𝗍</a>
+     <li><a href="https://webassembly.github.io/spec/core/syntax/types.html#external-types">𝗀𝗅𝗈𝖻𝖺𝗅</a>
+     <li><a href="https://webassembly.github.io/spec/core/syntax/modules.html#syntax-module">𝗂𝗆𝗉𝗈𝗋𝗍𝗌</a>
+     <li><a href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-valtype">𝗂𝟥𝟤</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#values">𝗂𝟥𝟤.𝖼𝗈𝗇𝗌𝗍</a>
+     <li><a href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-valtype">𝗂𝟨𝟦</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#values">𝗂𝟨𝟦.𝖼𝗈𝗇𝗌𝗍</a>
+     <li><a href="https://webassembly.github.io/spec/core/syntax/types.html#external-types">𝗆𝖾𝗆</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-moduleinst">𝗆𝖾𝗆𝖺𝖽𝖽𝗋𝗌</a>
+     <li><a href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-frame">𝗆𝗈𝖽𝗎𝗅𝖾</a>
+     <li><a href="https://webassembly.github.io/spec/core/syntax/types.html#external-types">𝗍𝖺𝖻𝗅𝖾</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
+    <ul>
+     <li><a href="https://heycam.github.io/webidl/#BufferSource">BufferSource</a>
+     <li><a href="https://heycam.github.io/webidl/#EnforceRange">EnforceRange</a>
+     <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
+     <li><a href="https://heycam.github.io/webidl/#Function">Function</a>
+     <li><a href="https://heycam.github.io/webidl/#LegacyNamespace">LegacyNamespace</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-USVString">USVString</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">get a copy of the buffer source</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-object">object</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-present">present</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>
+    </ul>
+  </ul>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
+  <dl>
+   <dt id="biblio-css-values-3">[CSS-VALUES-3]
+   <dd>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-values-3/">CSS Values and Units Module Level 3</a>. 29 September 2016. CR. URL: <a href="https://www.w3.org/TR/css-values-3/">https://www.w3.org/TR/css-values-3/</a>
+   <dt id="biblio-ecmascript">[ECMASCRIPT]
+   <dd><a href="https://tc39.github.io/ecma262/">ECMAScript Language Specification</a>. URL: <a href="https://tc39.github.io/ecma262/">https://tc39.github.io/ecma262/</a>
+   <dt id="biblio-encoding">[ENCODING]
+   <dd>Anne van Kesteren. <a href="https://encoding.spec.whatwg.org/">Encoding Standard</a>. Living Standard. URL: <a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a>
+   <dt id="biblio-html">[HTML]
+   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-infra">[INFRA]
+   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+   <dt id="biblio-promises-guide">[PROMISES-GUIDE]
+   <dd>Domenic Denicola. <a href="https://www.w3.org/2001/tag/doc/promises-guide">Writing Promise-Using Specifications</a>. 16 February 2016. Finding of the W3C TAG. URL: <a href="https://www.w3.org/2001/tag/doc/promises-guide">https://www.w3.org/2001/tag/doc/promises-guide</a>
+   <dt id="biblio-rfc2119">[RFC2119]
+   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-url">[URL]
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+   <dt id="biblio-webassembly">[WEBASSEMBLY]
+   <dd><a href="https://webassembly.github.io/spec/core/">WebAssembly Core Specification</a>. Draft. URL: <a href="https://webassembly.github.io/spec/core/">https://webassembly.github.io/spec/core/</a>
+   <dt id="biblio-webidl">[WebIDL]
+   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+  </dl>
+  <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
+<pre class="idl highlight def"><span class="kt">dictionary</span> <a class="nv" href="#dictdef-webassemblyinstantiatedsource"><code>WebAssemblyInstantiatedSource</code></a> {
+    <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#module" id="ref-for-module①③">Module</a> <a class="nv" data-type="Module " href="#dom-webassemblyinstantiatedsource-module"><code>module</code></a>;
+    <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#instance" id="ref-for-instance⑥">Instance</a> <a class="nv" data-type="Instance " href="#dom-webassemblyinstantiatedsource-instance"><code>instance</code></a>;
+};
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑤">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>,<span class="n">Worklet</span>)]
+<span class="kt">namespace</span> <a class="nv" href="#namespacedef-webassembly"><code>WebAssembly</code></a> {
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-webassembly-validate" id="ref-for-dom-webassembly-validate①">validate</a>(<a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#BufferSource" id="ref-for-BufferSource⑥">BufferSource</a> <a class="nv" href="#dom-webassembly-validate-bytes-bytes"><code>bytes</code></a>);
+    <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#module" id="ref-for-module①②">Module</a>> <a class="nv idl-code" data-link-type="method" href="#dom-webassembly-compile" id="ref-for-dom-webassembly-compile①">compile</a>(<a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#BufferSource" id="ref-for-BufferSource①①">BufferSource</a> <a class="nv" href="#dom-webassembly-compile-bytes-bytes"><code>bytes</code></a>);
+
+    <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-webassemblyinstantiatedsource" id="ref-for-dictdef-webassemblyinstantiatedsource②">WebAssemblyInstantiatedSource</a>> <a class="nv idl-code" data-link-type="method" href="#dom-webassembly-instantiate" id="ref-for-dom-webassembly-instantiate①">instantiate</a>(
+        <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#BufferSource" id="ref-for-BufferSource②①">BufferSource</a> <a class="nv" href="#dom-webassembly-instantiate-bytes-importobject-bytes"><code>bytes</code></a>, <span class="kt">optional</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object④"><span class="kt">object</span></a> <a class="nv" href="#dom-webassembly-instantiate-bytes-importobject-importobject"><code>importObject</code></a>);
+
+    <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#instance" id="ref-for-instance①①">Instance</a>> <a class="nv idl-code" data-link-type="method" href="#dom-webassembly-instantiate-moduleobject-importobject" id="ref-for-dom-webassembly-instantiate-moduleobject-importobject①">instantiate</a>(
+        <a class="n" data-link-type="idl-name" href="#module" id="ref-for-module②①">Module</a> <a class="nv" href="#dom-webassembly-instantiate-moduleobject-importobject-moduleobject"><code>moduleObject</code></a>, <span class="kt">optional</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object①①"><span class="kt">object</span></a> <a class="nv" href="#dom-webassembly-instantiate-moduleobject-importobject-importobject"><code>importObject</code></a>);
+};
+
+<span class="kt">enum</span> <a class="nv" href="#enumdef-importexportkind"><code>ImportExportKind</code></a> {
+  <a class="s" href="#dom-importexportkind-function"><code>"function"</code></a>,
+  <a class="s" href="#dom-importexportkind-table"><code>"table"</code></a>,
+  <a class="s" href="#dom-importexportkind-memory"><code>"memory"</code></a>,
+  <a class="s" href="#dom-importexportkind-global"><code>"global"</code></a>
+};
+
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-moduleexportdescriptor"><code>ModuleExportDescriptor</code></a> {
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString④"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-moduleexportdescriptor-name"><code>name</code></a>;
+  <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-importexportkind" id="ref-for-enumdef-importexportkind②">ImportExportKind</a> <a class="nv" data-type="ImportExportKind " href="#dom-moduleexportdescriptor-kind"><code>kind</code></a>;
+  // Note: Other fields such as signature may be added in the future.
+};
+
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-moduleimportdescriptor"><code>ModuleImportDescriptor</code></a> {
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①①"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-moduleimportdescriptor-module"><code>module</code></a>;
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②①"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-moduleimportdescriptor-name"><code>name</code></a>;
+  <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-importexportkind" id="ref-for-enumdef-importexportkind①①">ImportExportKind</a> <a class="nv" data-type="ImportExportKind " href="#dom-moduleimportdescriptor-kind"><code>kind</code></a>;
+};
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace⑦">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly⑦">WebAssembly</a>, <a class="nv idl-code" data-link-type="constructor" href="#dom-module-module" id="ref-for-dom-module-module①">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#BufferSource" id="ref-for-BufferSource⑤①">BufferSource</a> <a class="nv" href="#dom-module-module-bytes-bytes"><code>bytes</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>,<span class="n">Worklet</span>)]
+<span class="kt">interface</span> <a class="nv" href="#module"><code>Module</code></a> {
+  <span class="kt">static</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-moduleexportdescriptor" id="ref-for-dictdef-moduleexportdescriptor②">ModuleExportDescriptor</a>> <a class="nv" href="#dom-module-exports"><code>exports</code></a>(<a class="n" data-link-type="idl-name" href="#module" id="ref-for-module⑦①">Module</a> <a class="nv" href="#dom-module-exports-module-module"><code>module</code></a>);
+  <span class="kt">static</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-moduleimportdescriptor" id="ref-for-dictdef-moduleimportdescriptor②">ModuleImportDescriptor</a>> <a class="nv" href="#dom-module-imports"><code>imports</code></a>(<a class="n" data-link-type="idl-name" href="#module" id="ref-for-module⑧①">Module</a> <a class="nv" href="#dom-module-imports-module-module"><code>module</code></a>);
+  <span class="kt">static</span> <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects" id="ref-for-sec-arraybuffer-objects①①"><span class="kt">ArrayBuffer</span></a>> <a class="nv" href="#dom-module-customsections"><code>customSections</code></a>(<a class="n" data-link-type="idl-name" href="#module" id="ref-for-module⑨①">Module</a> <a class="nv" href="#dom-module-customsections-module-sectionname-module"><code>module</code></a>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③①"><span class="kt">USVString</span></a> <a class="nv" href="#dom-module-customsections-module-sectionname-sectionname"><code>sectionName</code></a>);
+};
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace①①">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly①①">WebAssembly</a>, <a class="nv idl-code" data-link-type="constructor" href="#dom-instance-instance" id="ref-for-dom-instance-instance①">Constructor</a>(<a class="n" data-link-type="idl-name" href="#module" id="ref-for-module①⓪①">Module</a> <a class="nv" href="#dom-instance-instance-module-importobject-module"><code>module</code></a>, <span class="kt">optional</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object②①"><span class="kt">object</span></a> <a class="nv" href="#dom-instance-instance-module-importobject-importobject"><code>importObject</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②①">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>,<span class="n">Worklet</span>)]
+<span class="kt">interface</span> <a class="nv" href="#instance"><code>Instance</code></a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object③①"><span class="kt">object</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="object" href="#dom-instance-exports" id="ref-for-dom-instance-exports①">exports</a>;
+};
+
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-memorydescriptor"><code>MemoryDescriptor</code></a> {
+  <span class="kt">required</span> [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange⑧">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv" data-type="[EnforceRange] unsigned long " href="#dom-memorydescriptor-initial"><code>initial</code></a>;
+  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange①①">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①②"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv" data-type="unsigned long " href="#dom-memorydescriptor-maximum"><code>maximum</code></a>;
+};
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace②①">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly②①">WebAssembly</a>, <a class="nv idl-code" data-link-type="constructor" href="#dom-memory-memory" id="ref-for-dom-memory-memory①">Constructor</a>(<a class="n" data-link-type="idl-name" href="#dictdef-memorydescriptor" id="ref-for-dictdef-memorydescriptor①">MemoryDescriptor</a> <a class="nv" href="#dom-memory-memory-descriptor-descriptor"><code>descriptor</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③①">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>,<span class="n">Worklet</span>)]
+<span class="kt">interface</span> <a class="nv" href="#memory"><code>Memory</code></a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-memory-grow" id="ref-for-dom-memory-grow②">grow</a>([<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange②①">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv" href="#dom-memory-grow-delta-delta"><code>delta</code></a>);
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects" id="ref-for-sec-arraybuffer-objects④①"><span class="kt">ArrayBuffer</span></a> <a class="nv" data-readonly="" data-type="ArrayBuffer" href="#dom-memory-buffer"><code>buffer</code></a>;
+};
+
+<span class="kt">enum</span> <a class="nv" href="#enumdef-tablekind"><code>TableKind</code></a> {
+  <a class="s" href="#dom-tablekind-anyfunc"><code>"anyfunc"</code></a>,
+  // Note: More values may be added in future iterations,
+  // e.g., typed function references, typed GC references
+};
+
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-tabledescriptor"><code>TableDescriptor</code></a> {
+  <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-tablekind" id="ref-for-enumdef-tablekind①">TableKind</a> <a class="nv" data-type="TableKind " href="#dom-tabledescriptor-element"><code>element</code></a>;
+  <span class="kt">required</span> [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange③①">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv" data-type="[EnforceRange] unsigned long " href="#dom-tabledescriptor-initial"><code>initial</code></a>;
+  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange④①">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv" data-type="unsigned long " href="#dom-tabledescriptor-maximum"><code>maximum</code></a>;
+};
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace③①">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly③①">WebAssembly</a>, <a class="nv idl-code" data-link-type="constructor" href="#dom-table-table" id="ref-for-dom-table-table①">Constructor</a>(<a class="n" data-link-type="idl-name" href="#dictdef-tabledescriptor" id="ref-for-dictdef-tabledescriptor①">TableDescriptor</a> <a class="nv" href="#dom-table-table-descriptor-descriptor"><code>descriptor</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④①">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>,<span class="n">Worklet</span>)]
+<span class="kt">interface</span> <a class="nv" href="#table"><code>Table</code></a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑥①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv" href="#dom-table-grow"><code>grow</code></a>([<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange⑤①">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑦①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv" href="#dom-table-grow-delta-delta"><code>delta</code></a>);
+  <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#Function" id="ref-for-Function②">Function</a>? <a class="nv idl-code" data-link-type="method" href="#dom-table-get" id="ref-for-dom-table-get①">get</a>([<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange⑥①">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑧①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv" href="#dom-table-get-index-index"><code>index</code></a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-table-set" id="ref-for-dom-table-set①">set</a>([<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange⑦①">EnforceRange</a>] <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑨①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv" href="#dom-table-set-index-value-index"><code>index</code></a>, <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#Function" id="ref-for-Function①①">Function</a>? <a class="nv" href="#dom-table-set-index-value-value"><code>value</code></a>);
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⓪①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-table-length" id="ref-for-dom-table-length①">length</a>;
+};
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace④①">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly④①">WebAssembly</a>]
+<span class="kt">interface</span> <a class="nv" href="#compileerror"><code>CompileError</code></a> { };
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace⑤①">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly⑤①">WebAssembly</a>]
+<span class="kt">interface</span> <a class="nv" href="#linkerror"><code>LinkError</code></a> { };
+
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#LegacyNamespace" id="ref-for-LegacyNamespace⑥①">LegacyNamespace</a>=<a class="n" data-link-type="idl-name" href="#namespacedef-webassembly" id="ref-for-namespacedef-webassembly⑥①">WebAssembly</a>]
+<span class="kt">interface</span> <a class="nv" href="#runtimeerror"><code>RuntimeError</code></a> { };
+
+</pre>
+  <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
+  <div style="counter-reset:issue">
+   <div class="issue"> Any attempts to <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">detach</a> <var>buffer</var>, other than the detachment performed by <code class="idl"><a data-link-type="idl" href="#dom-memory-grow">grow(delta)</a></code>, will throw a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> exception. Specifying this behavior <a href="https://github.com/tc39/ecma262/issues/1024">requires changes to the ECMAScript specification</a>.<a href="#issue-cb23e866"> ↵ </a></div>
+  </div>
+  <aside class="dfn-panel" data-for="associated-store">
+   <b><a href="#associated-store">#associated-store</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-associated-store">3. The WebAssembly Namespace</a> <a href="#ref-for-associated-store①">(2)</a>
+    <li><a href="#ref-for-associated-store②">3.3. Memories</a> <a href="#ref-for-associated-store③">(2)</a> <a href="#ref-for-associated-store④">(3)</a> <a href="#ref-for-associated-store⑤">(4)</a>
+    <li><a href="#ref-for-associated-store⑥">3.4. Tables</a> <a href="#ref-for-associated-store⑦">(2)</a> <a href="#ref-for-associated-store⑧">(3)</a> <a href="#ref-for-associated-store⑨">(4)</a> <a href="#ref-for-associated-store①⓪">(5)</a> <a href="#ref-for-associated-store①①">(6)</a>
+    <li><a href="#ref-for-associated-store①②">3.5. Exported Functions</a> <a href="#ref-for-associated-store①③">(2)</a> <a href="#ref-for-associated-store①④">(3)</a> <a href="#ref-for-associated-store①⑤">(4)</a> <a href="#ref-for-associated-store①⑥">(5)</a> <a href="#ref-for-associated-store①⑦">(6)</a> <a href="#ref-for-associated-store①⑧">(7)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="identified-with">
+   <b><a href="#identified-with">#identified-with</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-identified-with">3.3. Memories</a> <a href="#ref-for-identified-with①">(2)</a> <a href="#ref-for-identified-with②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="memory-object-cache">
+   <b><a href="#memory-object-cache">#memory-object-cache</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-memory-object-cache">3.3. Memories</a> <a href="#ref-for-memory-object-cache①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="table-object-cache">
+   <b><a href="#table-object-cache">#table-object-cache</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-table-object-cache">3.4. Tables</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="exported-function-cache">
+   <b><a href="#exported-function-cache">#exported-function-cache</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-exported-function-cache">3.5. Exported Functions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-webassemblyinstantiatedsource">
+   <b><a href="#dictdef-webassemblyinstantiatedsource">#dictdef-webassemblyinstantiatedsource</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-webassemblyinstantiatedsource">3. The WebAssembly Namespace</a> <a href="#ref-for-dictdef-webassemblyinstantiatedsource①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-webassemblyinstantiatedsource-module">
+   <b><a href="#dom-webassemblyinstantiatedsource-module">#dom-webassemblyinstantiatedsource-module</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-webassemblyinstantiatedsource-module">3. The WebAssembly Namespace</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-webassemblyinstantiatedsource-instance">
+   <b><a href="#dom-webassemblyinstantiatedsource-instance">#dom-webassemblyinstantiatedsource-instance</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-webassemblyinstantiatedsource-instance">3. The WebAssembly Namespace</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="namespacedef-webassembly">
+   <b><a href="#namespacedef-webassembly">#namespacedef-webassembly</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-namespacedef-webassembly">3.1. Modules</a>
+    <li><a href="#ref-for-namespacedef-webassembly①">3.2. Instances</a>
+    <li><a href="#ref-for-namespacedef-webassembly②">3.3. Memories</a>
+    <li><a href="#ref-for-namespacedef-webassembly③">3.4. Tables</a>
+    <li><a href="#ref-for-namespacedef-webassembly④">3.6. Error Objects</a> <a href="#ref-for-namespacedef-webassembly⑤">(2)</a> <a href="#ref-for-namespacedef-webassembly⑥">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="compile-a-webassembly-module">
+   <b><a href="#compile-a-webassembly-module">#compile-a-webassembly-module</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-compile-a-webassembly-module">3. The WebAssembly Namespace</a> <a href="#ref-for-compile-a-webassembly-module①">(2)</a>
+    <li><a href="#ref-for-compile-a-webassembly-module②">3.1. Modules</a>
+    <li><a href="#ref-for-compile-a-webassembly-module③">5. Integration with ECMAScript modules</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-webassembly-validate">
+   <b><a href="#dom-webassembly-validate">#dom-webassembly-validate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-webassembly-validate">3. The WebAssembly Namespace</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="construct-a-webassembly-module-object">
+   <b><a href="#construct-a-webassembly-module-object">#construct-a-webassembly-module-object</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-construct-a-webassembly-module-object">3. The WebAssembly Namespace</a>
+    <li><a href="#ref-for-construct-a-webassembly-module-object①">3.1. Modules</a>
+    <li><a href="#ref-for-construct-a-webassembly-module-object②">5. Integration with ECMAScript modules</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="asynchronously-compile-a-webassembly-module">
+   <b><a href="#asynchronously-compile-a-webassembly-module">#asynchronously-compile-a-webassembly-module</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-asynchronously-compile-a-webassembly-module">3. The WebAssembly Namespace</a> <a href="#ref-for-asynchronously-compile-a-webassembly-module①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-webassembly-compile">
+   <b><a href="#dom-webassembly-compile">#dom-webassembly-compile</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-webassembly-compile">3. The WebAssembly Namespace</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="instantiate-a-webassembly-module">
+   <b><a href="#instantiate-a-webassembly-module">#instantiate-a-webassembly-module</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-instantiate-a-webassembly-module">3. The WebAssembly Namespace</a> <a href="#ref-for-instantiate-a-webassembly-module①">(2)</a>
+    <li><a href="#ref-for-instantiate-a-webassembly-module②">3.2. Instances</a>
+    <li><a href="#ref-for-instantiate-a-webassembly-module③">5.4. ModuleExecution ( ) Concrete Method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="index-of-the-host-function">
+   <b><a href="#index-of-the-host-function">#index-of-the-host-function</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-index-of-the-host-function">3.5. Exported Functions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="instantiate-a-promise-of-a-module">
+   <b><a href="#instantiate-a-promise-of-a-module">#instantiate-a-promise-of-a-module</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-instantiate-a-promise-of-a-module">3. The WebAssembly Namespace</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-webassembly-instantiate">
+   <b><a href="#dom-webassembly-instantiate">#dom-webassembly-instantiate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-webassembly-instantiate">3. The WebAssembly Namespace</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-webassembly-instantiate-moduleobject-importobject">
+   <b><a href="#dom-webassembly-instantiate-moduleobject-importobject">#dom-webassembly-instantiate-moduleobject-importobject</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-webassembly-instantiate-moduleobject-importobject">3. The WebAssembly Namespace</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="enumdef-importexportkind">
+   <b><a href="#enumdef-importexportkind">#enumdef-importexportkind</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-importexportkind">3.1. Modules</a> <a href="#ref-for-enumdef-importexportkind①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-moduleexportdescriptor">
+   <b><a href="#dictdef-moduleexportdescriptor">#dictdef-moduleexportdescriptor</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-moduleexportdescriptor">3.1. Modules</a> <a href="#ref-for-dictdef-moduleexportdescriptor①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-moduleexportdescriptor-name">
+   <b><a href="#dom-moduleexportdescriptor-name">#dom-moduleexportdescriptor-name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-moduleexportdescriptor-name">3.1. Modules</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-moduleexportdescriptor-kind">
+   <b><a href="#dom-moduleexportdescriptor-kind">#dom-moduleexportdescriptor-kind</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-moduleexportdescriptor-kind">3.1. Modules</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-moduleimportdescriptor">
+   <b><a href="#dictdef-moduleimportdescriptor">#dictdef-moduleimportdescriptor</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-moduleimportdescriptor">3.1. Modules</a> <a href="#ref-for-dictdef-moduleimportdescriptor①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-moduleimportdescriptor-module">
+   <b><a href="#dom-moduleimportdescriptor-module">#dom-moduleimportdescriptor-module</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-moduleimportdescriptor-module">3.1. Modules</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-moduleimportdescriptor-name">
+   <b><a href="#dom-moduleimportdescriptor-name">#dom-moduleimportdescriptor-name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-moduleimportdescriptor-name">3.1. Modules</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-moduleimportdescriptor-kind">
+   <b><a href="#dom-moduleimportdescriptor-kind">#dom-moduleimportdescriptor-kind</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-moduleimportdescriptor-kind">3.1. Modules</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="module">
+   <b><a href="#module">#module</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-module">3. The WebAssembly Namespace</a> <a href="#ref-for-module①">(2)</a> <a href="#ref-for-module②">(3)</a> <a href="#ref-for-module③">(4)</a> <a href="#ref-for-module④">(5)</a> <a href="#ref-for-module⑤">(6)</a> <a href="#ref-for-module⑥">(7)</a>
+    <li><a href="#ref-for-module⑦">3.1. Modules</a> <a href="#ref-for-module⑧">(2)</a> <a href="#ref-for-module⑨">(3)</a>
+    <li><a href="#ref-for-module①⓪">3.2. Instances</a>
+    <li><a href="#ref-for-module①①">5. Integration with ECMAScript modules</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="string-value-of-the-extern-type">
+   <b><a href="#string-value-of-the-extern-type">#string-value-of-the-extern-type</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-string-value-of-the-extern-type">3.1. Modules</a> <a href="#ref-for-string-value-of-the-extern-type①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-module-module">
+   <b><a href="#dom-module-module">#dom-module-module</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-module-module">3.1. Modules</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="instance">
+   <b><a href="#instance">#instance</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-instance">3. The WebAssembly Namespace</a> <a href="#ref-for-instance①">(2)</a> <a href="#ref-for-instance②">(3)</a>
+    <li><a href="#ref-for-instance③">3.2. Instances</a>
+    <li><a href="#ref-for-instance④">3.3. Memories</a>
+    <li><a href="#ref-for-instance⑤">3.4. Tables</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-instance-instance">
+   <b><a href="#dom-instance-instance">#dom-instance-instance</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-instance-instance">3.2. Instances</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-instance-exports">
+   <b><a href="#dom-instance-exports">#dom-instance-exports</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-instance-exports">3.2. Instances</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-memorydescriptor">
+   <b><a href="#dictdef-memorydescriptor">#dictdef-memorydescriptor</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-memorydescriptor">3.3. Memories</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="memory">
+   <b><a href="#memory">#memory</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-memory">2.1. Interaction of the WebAssembly Store with JavaScript</a>
+    <li><a href="#ref-for-memory①">2.2. WebAssembly JS Object Caches</a>
+    <li><a href="#ref-for-memory②">3. The WebAssembly Namespace</a> <a href="#ref-for-memory③">(2)</a>
+    <li><a href="#ref-for-memory④">3.3. Memories</a> <a href="#ref-for-memory⑤">(2)</a> <a href="#ref-for-memory⑥">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="create-a-memory-object">
+   <b><a href="#create-a-memory-object">#create-a-memory-object</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-create-a-memory-object">3. The WebAssembly Namespace</a>
+    <li><a href="#ref-for-create-a-memory-object①">3.3. Memories</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-memory-memory">
+   <b><a href="#dom-memory-memory">#dom-memory-memory</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-memory-memory">3.3. Memories</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="reset-the-memory-buffer">
+   <b><a href="#reset-the-memory-buffer">#reset-the-memory-buffer</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-reset-the-memory-buffer">3.3. Memories</a> <a href="#ref-for-reset-the-memory-buffer①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-memory-grow">
+   <b><a href="#dom-memory-grow">#dom-memory-grow</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-memory-grow">3.3. Memories</a> <a href="#ref-for-dom-memory-grow①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="enumdef-tablekind">
+   <b><a href="#enumdef-tablekind">#enumdef-tablekind</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-tablekind">3.4. Tables</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-tabledescriptor">
+   <b><a href="#dictdef-tabledescriptor">#dictdef-tabledescriptor</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-tabledescriptor">3.4. Tables</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="table">
+   <b><a href="#table">#table</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-table">2.2. WebAssembly JS Object Caches</a>
+    <li><a href="#ref-for-table①">3. The WebAssembly Namespace</a>
+    <li><a href="#ref-for-table②">3.4. Tables</a> <a href="#ref-for-table③">(2)</a> <a href="#ref-for-table④">(3)</a> <a href="#ref-for-table⑤">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="create-a-table-object">
+   <b><a href="#create-a-table-object">#create-a-table-object</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-create-a-table-object">3. The WebAssembly Namespace</a>
+    <li><a href="#ref-for-create-a-table-object①">3.4. Tables</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-table-table">
+   <b><a href="#dom-table-table">#dom-table-table</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-table-table">3.4. Tables</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-table-length">
+   <b><a href="#dom-table-length">#dom-table-length</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-table-length">3.4. Tables</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-table-get">
+   <b><a href="#dom-table-get">#dom-table-get</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-table-get">3.4. Tables</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-table-set">
+   <b><a href="#dom-table-set">#dom-table-set</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-table-set">3.4. Tables</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="exported-function">
+   <b><a href="#exported-function">#exported-function</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-exported-function">2.2. WebAssembly JS Object Caches</a>
+    <li><a href="#ref-for-exported-function①">3. The WebAssembly Namespace</a>
+    <li><a href="#ref-for-exported-function②">3.4. Tables</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="name-of-the-webassembly-function">
+   <b><a href="#name-of-the-webassembly-function">#name-of-the-webassembly-function</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-name-of-the-webassembly-function">3.5. Exported Functions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="a-new-exported-function">
+   <b><a href="#a-new-exported-function">#a-new-exported-function</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-a-new-exported-function">3. The WebAssembly Namespace</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="call-an-exported-function">
+   <b><a href="#call-an-exported-function">#call-an-exported-function</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-call-an-exported-function">3.5. Exported Functions</a> <a href="#ref-for-call-an-exported-function①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="create-a-host-function">
+   <b><a href="#create-a-host-function">#create-a-host-function</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-create-a-host-function">3. The WebAssembly Namespace</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="tojsvalue">
+   <b><a href="#tojsvalue">#tojsvalue</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-tojsvalue">3. The WebAssembly Namespace</a>
+    <li><a href="#ref-for-tojsvalue①">3.5. Exported Functions</a> <a href="#ref-for-tojsvalue②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="towebassemblyvalue">
+   <b><a href="#towebassemblyvalue">#towebassemblyvalue</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-towebassemblyvalue">3. The WebAssembly Namespace</a>
+    <li><a href="#ref-for-towebassemblyvalue①">3.5. Exported Functions</a> <a href="#ref-for-towebassemblyvalue②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="compileerror">
+   <b><a href="#compileerror">#compileerror</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-compileerror">3. The WebAssembly Namespace</a>
+    <li><a href="#ref-for-compileerror①">3.1. Modules</a>
+    <li><a href="#ref-for-compileerror②">3.6. Error Objects</a>
+    <li><a href="#ref-for-compileerror③">5. Integration with ECMAScript modules</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="linkerror">
+   <b><a href="#linkerror">#linkerror</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-linkerror">3. The WebAssembly Namespace</a> <a href="#ref-for-linkerror①">(2)</a> <a href="#ref-for-linkerror②">(3)</a> <a href="#ref-for-linkerror③">(4)</a> <a href="#ref-for-linkerror④">(5)</a> <a href="#ref-for-linkerror⑤">(6)</a>
+    <li><a href="#ref-for-linkerror⑥">3.6. Error Objects</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="runtimeerror">
+   <b><a href="#runtimeerror">#runtimeerror</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-runtimeerror">3. The WebAssembly Namespace</a>
+    <li><a href="#ref-for-runtimeerror①">3.5. Exported Functions</a>
+    <li><a href="#ref-for-runtimeerror②">3.6. Error Objects</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="parse-a-webassembly-module">
+   <b><a href="#parse-a-webassembly-module">#parse-a-webassembly-module</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-parse-a-webassembly-module">5.5. Modifications to HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="export-name-list">
+   <b><a href="#export-name-list">#export-name-list</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-export-name-list">5.1. GetExportedNames ( exportStarSet ) Concrete Method</a>
+    <li><a href="#ref-for-export-name-list①">5.2. ResolveExport ( exportName, resolveSet ) Concrete Method</a>
+    <li><a href="#ref-for-export-name-list②">5.3. ModuleDeclarationEnvironmentSetup ( ) Concrete Method</a>
+    <li><a href="#ref-for-export-name-list③">5.4. ModuleExecution ( ) Concrete Method</a>
+   </ul>
+  </aside>
+<script>/* script-dfn-panel */
+
+        document.body.addEventListener("click", function(e) {
+            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+            // Find the dfn element or panel, if any, that was clicked on.
+            var el = e.target;
+            var target;
+            var hitALink = false;
+            while(el.parentElement) {
+                if(el.tagName == "A") {
+                    // Clicking on a link in a <dfn> shouldn't summon the panel
+                    hitALink = true;
+                }
+                if(el.classList.contains("dfn-paneled")) {
+                    target = "dfn";
+                    break;
+                }
+                if(el.classList.contains("dfn-panel")) {
+                    target = "dfn-panel";
+                    break;
+                }
+                el = el.parentElement;
+            }
+            if(target != "dfn-panel") {
+                // Turn off any currently "on" or "activated" panels.
+                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+                    el.classList.remove("on");
+                    el.classList.remove("activated");
+                });
+            }
+            if(target == "dfn" && !hitALink) {
+                // open the panel
+                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+                if(dfnPanel) {
+                    console.log(dfnPanel);
+                    dfnPanel.classList.add("on");
+                    var rect = el.getBoundingClientRect();
+                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+                    dfnPanel.style.top = window.scrollY + rect.top + "px";
+                    var panelRect = dfnPanel.getBoundingClientRect();
+                    var panelWidth = panelRect.right - panelRect.left;
+                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                        // Reposition, because the panel is overflowing
+                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+                    }
+                } else {
+                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+                }
+            } else if(target == "dfn-panel") {
+                // Switch it to "activated" state, which pins it.
+                el.classList.add("activated");
+                el.style.left = null;
+                el.style.top = null;
+            }
+
+        });
+        </script>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -875,3 +875,86 @@ same class of exception is thrown as for out of memory conditions in JavaScript.
 The particular exception here is implementation-defined in both cases.
 
 Note: ECMAScript doesn't specify any sort of behavior on out-of-memory conditions; implementations have been observed to throw OOMError and to crash. Either is valid here.
+
+<h2 id="esm-integration">Integration with ECMAScript modules</h2>
+
+WebAssembly modules can be used in a module graph with ECMAScript modules.
+
+<dfn>WebAssembly Module Record</dfn>s are a subclass of <a href="https://github.com/tc39/ecma262/pull/1311">Circular Module Records</a> which contain WebAssembly code. WebAssembly Module Records has one additional internal slot:
+    * \[[WebAssemblyModule]] : a WebAssembly {{Module}} object
+
+<div algorithm>
+To <dfn>parse a WebAssembly module</dfn> given a an {{ArrayBuffer}} |body|, a Realm |realm| and object |hostDefined|, perform the following steps.
+
+1. [=Compile a WebAssembly module|Compile the WebAssembly module=] |stableBytes| and store the result as |module|.
+1. If |module| is [=error=], throw a {{CompileError}} exception.
+1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and let |module| be the result.
+1. Let |requestedModules| be a set.
+1. For each (|moduleName|, |name|, |type|) in [=module_imports=](|module|.\[[Module]]),
+    1. [=set/Append=] |moduleName| to |requestedModules|.
+1. Return { \[[Realm]]: |realm|, \[[Environment]]: undefined, \[[Namespace]]: undefined, \[[Status]]: "uninstantiated", \[[EvaluationError]]: undefined, \[[HostDefined]]: |hostDefined|, \[[WebAssemblyModule]]: |module|, \[[RequestedModules]]: |requestedModules|, \[[DFSIndex]]: undefined, \[[DFSAncestorIndex]]: undefined }.
+
+</div>
+
+<div algorithm>
+The <dfn>export name list</dfn> of a WebAssembly Module Record |record| is defined by the following algorithm:
+
+1. Let |module| be |record|'s \[[WebAssemblyModule]] internal slot.
+1. Let |exports| be an empty [=list=].
+1. For each (|name|, |type|) in [=module_exports=](|module|.\[[Module]])
+    1. [=Append=] |name| to the end of |exports|.
+1. Return |exports|.
+
+</div>
+
+WebAssembly Module Records have the following methods:
+
+<h3 id="get-exported-names">GetExportedNames ( |exportStarSet| ) Concrete Method</h3>
+1. Let |record| be this WebAssembly Module Record.
+1. Return the [=export name list=] of |record|.
+
+<h3 id="resolve-export">ResolveExport ( |exportName|, |resolveSet| ) Concrete Method</h3>
+1. Let |record| be this WebAssembly Module Record.
+1. If the [=export name list=] of |record| contains |exportName|, return { \[[Module]]: |record|, \[[BindingName]]: |exportName| }.
+1. Otherwise, return null.
+
+<h3 id="module-declaration-environment-setup">ModuleDeclarationEnvironmentSetup ( ) Concrete Method</h3>
+1. Let |record| be this WebAssembly Module Record.
+1. Let |env| be NewModuleEnvironment(null).
+1. Set |record|.\[[Environment]] to |env|.
+1. Let |envRec| be |env|'s EnvironmentRecord.
+1. For each |name| in the [=export name list=] of |record|,
+    1. Perform ! |envRec|.CreateImmutableBinding(|name|, true).
+
+<h3 id="module-execution">ModuleExecution ( ) Concrete Method</h3>
+1. Let |record| be this WebAssembly Module Record.
+1. Let |module| be |record|.\[[WebAssemblyModule]].
+1. Let |imports| be a new, empty [=map=].
+1. For each (|importedModuleName|, |name|, |type|) in [=module_imports=](|module|.\[[Module]]),
+    1. If |imports|[|importedModuleName|] does not exist, set |imports|[|importedModuleName|] to a new, empty [=map=].
+    1. Let |importedModule| be ! HostResolveImportedModule(|module|, |importedModuleName|).
+    1. NOTE: The above call cannot fail because imported module requests are a subset of |module|.\[[RequestedModules]], and these have been resolved earlier in this algorithm.
+    1. Let |value| be ? |importedModule|.\[[Environment]].GetBindingValue(|name|, true).
+    1. Set |imports|[|moduleName|][|name|] to |value|.
+1. Let |importsObject| be a new Object.
+1. For each |key| →  |value| of |imports|,
+    1. Let |moduleImportsObject| be a new Object.
+    1. For each |importedName| →  |importedValue| of |imports|,
+        1. Perform ! CreateDataPropertyOrThrow(|moduleImportsObject|, |importedName|, |importedValuealue|).
+    1. Perform ! CreateDataPropertyOrThrow(|importsObject|, |key|, |moduleImportsObject|).
+1. [=Instantiate a WebAssembly module=] |module| with imports |importsObject| and let |instance| be the result.
+1. Let |envRec| be the EnvironmentRecord of |record|.\[[Environment]].
+1. For each |name| in the [=export name list=] of |record|,
+    1. Perform ! |envRec|.InitializeBinding(|name|, ! Get(|instance|.\[[Exports]], |name|)).
+
+Note: Instantiating the WebAssembly module may yield to the task queue and is not guaranteed to be synchronous.
+
+<h3 id="html-modifications">Modifications to HTML</h3>
+
+The <a href="https://html.spec.whatwg.org/#fetch-a-single-module-script">fetch a single module script</a> algorithm, in Step 9, would switch off of the mimetype. If the response has a JavaScript mimetype, continue the algorithm. If it has a non-wasm mimetype, abort the algorithm. If it has an `application/wasm` mimetype, perform the following steps:
+
+1. Let |source| be |response|'s body as an {{ArrayBuffer}}
+1. <a href="https://html.spec.whatwg.org/#creating-a-module-script">Create a module script</a>, but with step 7 replacing ParseModule with the [=parse a WebAssembly Module=] algorithm.
+1. Set |moduleMap|[|url|] to to |module|
+
+TODO: Write this up as a PR against the HTML spec.

--- a/proposals/esm-integration/README.md
+++ b/proposals/esm-integration/README.md
@@ -88,11 +88,11 @@ Three things happen for each module during the Construction phase.
 
 ### Instantiation
 
-When `Module.Instantiate` is called on a JavaScript module, a Lexical Environment is set up. Space for exports is allocated and the memory locations are bound to the export name. Additionally, any imports from dependencies are resolved. In JS, functions are initialized at this point. All other values are undefined until evaluation.
+When `Module.Instantiate` is called on a JavaScript module, a Lexical Environment is set up. Space for exports is allocated and the memory locations are bound to the export name. Additionally, any imports from dependencies are resolved. In JS, function declarations are initialized at this point. All other values are undefined or in [TDZ](http://2ality.com/2015/10/why-tdz.html) (i.e. would lead to a ReferenceError on access) until evaluation.
 
-When `Module.Instantiate` is called on a WebAssembly module, the module will go through the same process. However, unlike in JavaScript, functions will not be initialized at this point. Initialization for all values happens during evaluation.
+When `Module.Instantiate` is called on a WebAssembly module, the module will go through the same process. A Lexical Environment is set up, and all exports (for functions, tables, memories and globals) have a binding created for them, which is initialized to TDZ. This process is not WebAssembly module instantiation--WebAssembly validation is not run at this point, and the start function is not executed. Unlike in JavaScript, functions will not be initialized at this point. Function exports, like other exports, start out as TDZ. Initialization of these bindings to take them out of TDZ for all values happens during evaluation.
 
-WebAssembly exports can be any one of the [external types] (https://webassembly.github.io/spec/core/exec/modules.html#external-typing), which currently include:
+WebAssembly exports can be any one of the [external types](https://webassembly.github.io/spec/core/exec/modules.html#external-typing), which currently include:
 
 - functions
 - tables
@@ -101,19 +101,27 @@ WebAssembly exports can be any one of the [external types] (https://webassembly.
 
 WebAssembly does not currently have a type that can handle arbitrary JS values. This means that JS value imports can not be handled with live bindings and will be snapshotted when they are imported. This means that if a JS module changes one of its exports to point to a different object, a WebAssembly module importing that object will not see the change.
 
-It may be possible to provide live bindings for JS values if an `any` type is added to WebAssembly.
+It may be possible to provide live bindings for JS values if an [`anyref`](https://github.com/WebAssembly/reference-types) type is added to WebAssembly.
 
 ### Evaluation
 
 During evaluation, the code is evaluated to assign values to the exported bindings. In JS, this means running the top-level module code.
 
-For WebAssembly, evaluation consists of:
-- initializing all exports and snapshotting all imports
-- filling in memory using the data segment
-- filling in tables using elem segments
-- running the start function, which corresponds to running the top-level module code
+WebAssembly has explicit types for both imports and exports. The type of exports is used to populate the lexical environment with a JavaScript value based on the WebAssembly export, from the [WebAssembly JS API](https://webassembly.github.io/spec/js-api/index.html). The type of imports is used to type check or convert imports to the required WebAssembly type.
 
-Because JS modules that the WebAssembly module imports from are already evaluated at this point, their values will be available for WebAssembly to snapshot.
+For WebAssembly, evaluation consists of:
+- validating the WebAssembly module
+- snapshotting all imports:
+    - If any import is in TDZ, throw a ReferenceError exception
+    - Type-check/coerce each imported value against the declared import type, per step 8 of the [*instantiate a WebAssembly module*](https://webassembly.github.io/spec/js-api/index.html#instantiate-a-webassembly-module) algorithm.
+    - Initialize ("snapshot") the imported bindings to the checked/coerced value
+- initializing the Wasm module, performing [Wasm module instantiation](https://webassembly.github.io/spec/core/appendix/embedding.html#embed-instantiate-module)
+    - filling in memory using the data segment
+    - filling in tables using elem segments
+    - running the start function, which corresponds to running the top-level module code
+- initializing all exports in the Lexical Environment to their analogous Wasm/JS API objects, per step 4 of the [*instantiate a WebAssembly module*](https://webassembly.github.io/spec/js-api/index.html#instantiate-a-webassembly-module) algorithm.
+
+Because JS modules that the WebAssembly module imports from are already evaluated at this point, their values will be available for WebAssembly to snapshot (as long as the WebAssembly module was not in a cycle with the JS module, with the WebAssembly module's evaluation preceding the JS module's evaluation).
 
 #### A note on snapshotting
 
@@ -127,20 +135,25 @@ Some imports are challenging to handle in the current WebAssembly specification.
 
 ### wasm imports <- JS exports
 
-| export type | value (not a WebAssembly.Global)* | global | memory | table | function |
-|-------------|------------------|--------|--------|-------|----------|
-|              | Error                         | snapshot  | snapshot  | snapshot | snapshot |
+When the Wasm module is evaluated, the exported value of the JS module is used in a way which is based on the import type declared in the WebAssembly module.
 
-\*While WebAssembly only has the concept of globals, JS could export either a regular JS value or a `WebAssembly.Global`.
+| import type | behavior |
+|-------------|----------|
+| global      | If the exported value is a WebAssembly.Global object, throw an exception if types mismatch, otherwise take that object as the import. Otherwise, if the imported type is `const`, cast the imported value to the appropriate numeric type, and create a new const global to hold the result. Otherwise, throw an exception. |
+| memory      | Check that the exported value is a WebAssembly.Memory object which meets the type imported; use it if so, otherwise, throw an exception |
+| table       | Check that the exported value is a WebAssembly.Table object which meets the type imported; use it if so, otherwise, throw an exception |
+| function    | If the exported value is a WebAssembly exported function based on the same types, make use of it. Otherwise, [create a host function](https://webassembly.github.io/spec/js-api/index.html#create-a-host-function) out of the JS function which includes the casts implied by its type. |
+
+While WebAssembly only has the concept of globals, JS could export either a regular JS value or a `WebAssembly.Global`.
 
 The sequence of operations for a wasm module which depends on a JS module is as follows:
 
 1. wasm module is parsed
 1. JS module is parsed
-1. JS module is instantiated. Function exports are initialized. Non-function exports are set to undefined.
-1. wasm module is instantiated. Imports are bound to memory locations but values are not snapshotted yet.
-1. JS module is evaluated. All of its remaining exports (i.e. non-fuction values) are initialized. 
-1. wasm module is evaluated. All exports are initialized. All imports are snapshotted.
+1. JS module is instantiated. Function declaration exports are initialized. Other exports are set to undefined or are in TDZ.
+1. wasm module has an exports lexical environment created. Imports are bound to memory locations but values are not snapshotted yet.
+1. JS module is evaluated. All of its remaining exports (i.e. non-fuction values) are initialized. Any top-level statements are executed.
+1. wasm module is instantiated and its start function runs. All imports are snapshotted. All exports are initialized.
 
 Note: because these are snapshots of values, this does not maintain the live-binding semantics that exists between JS modules. For example, let's say JS module exports a function, called `foo`. The WebAssembly module imports `foo`. Then, after evaluation, the JS module sets `foo` to a different function. Other JS modules would see this update. However, WebAssembly modules will not.
 
@@ -184,17 +197,20 @@ export {count};
 
 ### JS imports <- wasm exports
 
-| export type | global       | memory       | table        | function     |
-|-------------|--------------|--------------|--------------|--------------|
-|   | live binding | live binding | live binding | live binding |
+| export type | imported value            |
+|-------------|---------------------------|
+| global      | WebAssembly.Global object |
+| memory      | WebAssembly.Memory object |
+| table       | WebAssembly.Table object  |
+| function    | WebAssembly exported function |
 
-While these are live bindings, the binding can not be reassigned as it can in JS. But the value that it points to (e.g. `.value` in the case of `WebAssembly.Global`) can change.
+Wasm bindings cannot be reassigned as it can in JS, so the exported value will not change in their object identity. But the value that it points to (e.g. `.value` in the case of `WebAssembly.Global`) can change.
 
 1. JS module is parsed
 1. wasm module is parsed
-1. wasm module is instantiated. All exports are set to undefined.
+1. wasm module has a lexical environment created for its exports. All exports are initially in TDZ.
 1. JS module is instantiated. Imports are bound to the same memory locations.
-1. wasm module is evaluated. Functions are initialized. Memories and tables are initialized and filled with data/elem sections. Globals are initialized and initializer expressions are evaluated.
+1. wasm module is instantiated evaluated. Functions are initialized. Memories and tables are initialized and filled with data/elem sections. Globals are initialized and initializer expressions are evaluated. The start function runs.
 1. JS module is evaluated. All values are available.
 
 Currently, the value of the export for something like `WebAssembly.Global` would be accessed using the `.value` property on the JS object. However, when host bindings are in place, these could be annotated with a host binding that turns it into a real live binding that points directly to the value's address.
@@ -222,11 +238,7 @@ console.log(count.value); // logs 6
 
 ### wasm imports <- wasm exports
 
-| export type | global       | memory       | table        | function     |
-|-------------|--------------|--------------|--------------|--------------|
-|   | live binding | live binding | live binding | live binding |
-
-Wasm exports can be imported as live bindings to other wasm modules.
+Wasm exports can be imported as accurate, immutable bindings to other wasm modules. Types between imports and exports must match. Types are checked in the "evaluation" phase, when they undergo Wasm instantiation.
 
 #### Example
 
@@ -251,11 +263,7 @@ Wasm exports can be imported as live bindings to other wasm modules.
 
 ### wasm imports <- JS re-exports <- wasm exports
 
-| export type | global       | memory       | table        | function     |
-|-------------|--------------|--------------|--------------|--------------|
-|   | live binding | live binding | live binding | live binding |
-
-Any wasm exports that are re-exported via a JS module will be available to the other wasm module as live bindings. The memory location gets wrapped into a JS object (e.g. `WebAssembly.Global`) and then unwrapped to the memory location in the importing wasm module.
+Any wasm exports that are re-exported via a JS module will be available to the other wasm module as accurate, immutable bindings. The wasm export gets wrapped into a JS object (e.g. `WebAssembly.Global`) and then unwrapped to the wasm import in the importing wasm module. When imported from JS, the first and second Wasm modules will yield the same object identities for the multiply exported Wasm objects.
 
 #### Example
 
@@ -280,18 +288,18 @@ export {memoryExport} from "./b.wasm";
 #### JS exports
 | export type | value (not a WebAssembly.Global)* | global | memory | table | function |
 |-|-------------------------------|--------|--------|-------|----------|
-| | Error                         | Error  | Error  | Error | snapshot |
+| | 0 if a const import and not in TDZ, otherwise Error | Error  | Error  | Error | snapshot if it is a function declaration, otherwise Error |
 
 #### wasm exports
 | export type | global       | memory       | table        | function     |
 |-|--------------|--------------|--------------|--------------|
-| | live binding | live binding | live binding | live binding |
+| | accurate binding | accurate binding | accurate binding | accurate binding |
 
 1. JS module is parsed
 1. wasm module is parsed
-1. wasm module is instantiated. All exports are set to undefined.
+1. wasm module has a lexical environment created for its exports. All exports are initially in TDZ.
 1. JS module is instantiated. All imports (including functions) from the wasm module are memory locations holding undefined.
-1. wasm module is evaluated. Snapshots of imports are taken. Exports are initialized.
+1. wasm module is instantiated and evaluated. Snapshots of imports are taken. Export bindings are initialized.
 1. JS module is evaluated. 
 
 #### Example
@@ -316,7 +324,7 @@ export function functionExport() {
 #### wasm exports
 | export type | global       | memory       | table        | function     |
 |-|--------------|--------------|--------------|--------------|
-| | live binding | live binding | live binding | live binding |
+| | accurate binding | accurate binding | accurate binding | accurate binding |
 
 #### JS exports
 | export type | value (not a WebAssembly.Global)* | global | memory | table | function |
@@ -326,9 +334,9 @@ export function functionExport() {
 1. wasm module is parsed
 1. JS module is parsed
 1. JS module is instantiated. 
-1. wasm module is instantiated. All exports (including functions) from the wasm module are memory locations holding undefined.
-1. JS module is evaluated. wasm exports are still undefined
-1. wasm module is evaluated. 
+1. wasm module has a lexical environment created for its exports. All exports are initially in TDZ.
+1. JS module is evaluated. wasm exports lead to a ReferenceError if used.
+1. wasm module is instantiated and evaluated; wasm-exported bindings are updated to their appropriate JS API-exposed values. 
 
 #### Examples
 
@@ -349,8 +357,16 @@ export function functionExport() {
 
 ### wasm <-> wasm cycle
 
-| export type | global | memory | table | function |
-|-|--------|--------|-------|----------|
-| | Error  | Error  | Error | Error    |
+In this initial version of Wasm/ESM integration, a wasm<->wasm cycle is an error. There are two possible paths to possible circular Wasm module imports, described in the next section.
 
-@TODO explain why we need to throw on WebAssembly cycles
+#### Break up instantiation into two phrases -- infeasible
+
+A core design point of this proposal is that WebAssembly modules are instantiated one by one. The WebAssembly module instantiation path includes validation, type checking, reading imports, exposing exports and running the "start" function. By contrast, the JavaScript specification is broken up into two phases, one to identify and initialize the imports/exports, and one to make use of them. The difference is motivated, in part, by the fact that updating the bindings on the JavaScript end has fixed behavior--because the language is dynamically typed, the process is just updating a binding. By contrast, in WebAssembly, that binding needs to have its type checked.
+
+In a planned WebAssembly feature, the [GC v1](https://github.com/WebAssembly/gc/blob/master/proposals/gc/MVP.md) proposal, WebAssembly will get the ability to import types from other modules. With this, at the time that types are being checked, it is essential that that type be available. To accommodate this proposal, circular modules which import types from each other are impossible. Instantiation must be one phase which happens together, including importing the actual types (not just abstract bindings over the types) to use in module type checking.
+
+#### Use a trampoline to implement live bindings of functions -- possible follow-on proposal
+
+Since instantiation is one-by-one, if we allow circular modules, it will not be possible to call a function from a module that has not yet been instantiated. So, from a start function, it would be necessary to check whether a function has been instantiated yet or not. WebAssembly is based on a design philosophy of no additional runtime overhead from dynamic checks. Including a check like this by default and trying to optimize it out sometimes would go contrary to that philosophy.
+
+Instead of including this check in the default semantics of functions, a trampoline can be explicitly constructed which does this check and passes control on to the maybe-initialized function. Initially, this trampoline can be constructed by build tools like webpack. In a potential follow-on proposal, the trampoline may be generated natively, as part of the host-bindings proposal. See https://github.com/WebAssembly/esm-integration/issues/17 for details.


### PR DESCRIPTION
- Initialize Wasm exports in TDZ; closes #18
- Document motivation for no circular modules and circular imports
  of functions as a follow-on; closes #17
- Avoid use of the term "live binding"; closes #19
- Permit imports of Numbers as constant globals; closes #16